### PR TITLE
[BugFix] Enhanced LifeCycleEvents in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ allprojects {
 
 ```groovy
 
-implementation 'com.rudderstack.android.sdk:core:1.3.0'
+implementation 'com.rudderstack.android.sdk:core:1.3.1'
 ```
 
 ## Initializing ```RudderClient```

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
-        versionName '1.3.0'
+        versionName '1.3.1'
         consumerProguardFiles 'proguard-consumer-rules.pro'
     }
 
@@ -46,7 +46,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.rudderstack.android.sdk'
-    PUBLISH_VERSION = '1.3.0'
+    PUBLISH_VERSION = '1.3.1'
     PUBLISH_ARTIFACT_ID = 'core'
 }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -120,6 +120,9 @@ class EventRepository implements Application.ActivityLifecycleCallbacks {
 
             // check for lifeCycleEvents
             this.checkApplicationUpdateStatus(_application);
+            if (config.isTrackLifecycleEvents() || config.isRecordScreenViews()) {
+                _application.registerActivityLifecycleCallbacks(this);
+            }
         } catch (Exception ex) {
             RudderLogger.logError(ex.getCause());
         }
@@ -192,16 +195,12 @@ class EventRepository implements Application.ActivityLifecycleCallbacks {
                 versionCode = packageInfo.versionCode;
             }
             RudderLogger.logDebug("Current Installed Version: " + versionCode);
-            boolean isLifeCycleEventsAllowed = config.isTrackLifecycleEvents() || config.isRecordScreenViews();
-            if (isLifeCycleEventsAllowed) {
-                application.registerActivityLifecycleCallbacks(this);
-            }
 
             if (previousVersionCode == -1) {
                 // application was not installed previously, Application Installed event
                 preferenceManager.saveBuildVersionCode(versionCode);
                 // If trackLifeCycleEvents is not allowed then discard the event
-                if (!isLifeCycleEventsAllowed) {
+                if (!config.isTrackLifecycleEvents()) {
                     return;
                 }
                 RudderLogger.logDebug("Tracking Application Installed");
@@ -216,7 +215,7 @@ class EventRepository implements Application.ActivityLifecycleCallbacks {
             } else if (previousVersionCode != versionCode) {
                 preferenceManager.saveBuildVersionCode(versionCode);
                 // If either optOut() is set to true or LifeCycleEvents set to false then discard the event
-                if (getOptStatus() || !isLifeCycleEventsAllowed) {
+                if (getOptStatus() || !config.isTrackLifecycleEvents()) {
                     return;
                 }
                 // Application Updated event


### PR DESCRIPTION
## Description of the change

- Build version was not saving when LifeCycleEvents is set to false.
- When recordScreenView is set to true and trackLifeCycleEvent is set to false then lifeCycleEvents was flowing. Now if this condition occurs then only screen event will be sent.
- [Notion Card](https://www.notion.so/rudderstacks/d5d15ce4be354e3caae11d4ea9f41477?v=8081ceba15644c85ad7a2cfb918a9c51&p=03c96e5431a045419c4755e410a15aa7)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-android/107)
<!-- Reviewable:end -->
