### PR TITLE
Made Bluetooth permission optional 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Package name is changed from `com.rudderlabs.android.sdk.core` to `com.rudderstack.android.sdk.core`.
 - New field `userId` is supported to make it more compliant under `context->traits` for `identify` and all successive calls. Old filed for developer identification i.e. `id` is still supported. 
+
+## Version - 1.6.0 - 2022-07-11
+
+## Changed
+- Removed Bluetooth permission from the Core SDK and from now the bluetooth status would be collected and sent as a part of the payload only if bluetooth permission is included in the SDK, so that from now bluetooth permission is not necessarily needed to make use of the SDK.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ allprojects {
 
 ```groovy
 
-implementation 'com.rudderstack.android.sdk:core:1.5.2'
+implementation 'com.rudderstack.android.sdk:core:1.6.0'
 ```
 
 ## Initializing ```RudderClient```

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
-        versionName '1.5.2'
+        versionName '1.6.0'
         consumerProguardFiles 'proguard-consumer-rules.pro'
     }
 
@@ -54,7 +54,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.rudderstack.android.sdk'
-    PUBLISH_VERSION = '1.5.2'
+    PUBLISH_VERSION = '1.6.0'
     PUBLISH_ARTIFACT_ID = 'core'
 }
 

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.rudderstack.android.sdk.core">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" android:required="false"/>
-    <uses-permission android:name="android.permission.BLUETOOTH" android:required="false"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
@@ -33,5 +33,5 @@ class Constants {
     // whether we should record screen views automatically
     static final boolean RECORD_SCREEN_VIEWS = false;
     // current version of the library
-    static final String RUDDER_LIBRARY_VERSION = "1.5.2";
+    static final String RUDDER_LIBRARY_VERSION = "1.6.0";
 }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderLibraryInfo.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderLibraryInfo.java
@@ -6,5 +6,5 @@ class RudderLibraryInfo {
     @SerializedName("name")
     private String name = BuildConfig.LIBRARY_PACKAGE_NAME;
     @SerializedName("version")
-    private String version = "1.5.2";
+    private String version = "1.6.0";
 }

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <application
         android:name=".MainApplication"


### PR DESCRIPTION
## Made Bluetooth permission optional 

> Made Bluetooth permission optional and from now on the Bluetooth status would be reflected in the payload if and only if the Bluetooth permission is added by the end-user of the SDK

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#127](https://github.com/rudderlabs/rudder-sdk-android/issues/127) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-android/130)
<!-- Reviewable:end -->
