### PR TITLE
fix: sourceConfig issue by changing encoding to Base64.NO_WRAP

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -128,10 +128,9 @@ class EventRepository {
     private void updateAnonymousIdHeaderString() throws UnsupportedEncodingException {
         String anonymousId = RudderContext.getAnonymousId();
         RudderLogger.logDebug(String.format(Locale.US, "EventRepository: constructor: anonymousId: %s", anonymousId));
-        this.anonymousIdHeaderString = Base64.encodeToString(anonymousId.getBytes(CHARSET_UTF_8), Base64.DEFAULT);
+        this.anonymousIdHeaderString = Base64.encodeToString(anonymousId.getBytes(CHARSET_UTF_8), Base64.NO_WRAP);
         RudderLogger.logDebug(String.format(Locale.US, "EventRepository: constructor: anonymousIdHeaderString: %s", this.anonymousIdHeaderString));
     }
-
 
     private void initiatePreferenceManager(Application application, RudderConfig config, Identifiers identifiers) {
         preferenceManager = RudderPreferenceManager.getInstance(application);
@@ -149,10 +148,9 @@ class EventRepository {
     }
 
     private void updateAuthHeaderString(String writeKey) {
-
         try {
             RudderLogger.logDebug(String.format(Locale.US, "EventRepository: constructor: writeKey: %s", writeKey));
-            this.authHeaderString = Base64.encodeToString((String.format(Locale.US, "%s:", writeKey)).getBytes(CHARSET_UTF_8), Base64.DEFAULT);
+            this.authHeaderString = Base64.encodeToString((String.format(Locale.US, "%s:", writeKey)).getBytes(CHARSET_UTF_8), Base64.NO_WRAP);
             RudderLogger.logDebug(String.format(Locale.US, "EventRepository: constructor: authHeaderString: %s", this.authHeaderString));
         } catch (UnsupportedEncodingException ex) {
             RudderLogger.logError(ex);
@@ -350,7 +348,7 @@ class EventRepository {
         RudderElementCache.updateAnonymousId(anonymousId);
         preferenceManager.saveAnonymousId(RudderContext.getAnonymousId());
         try {
-            this.anonymousIdHeaderString = Base64.encodeToString(RudderContext.getAnonymousId().getBytes(CHARSET_UTF_8), Base64.DEFAULT);
+            this.anonymousIdHeaderString = Base64.encodeToString(RudderContext.getAnonymousId().getBytes(CHARSET_UTF_8), Base64.NO_WRAP);
         } catch (Exception ex) {
             RudderLogger.logError(ex.getCause());
         }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
@@ -60,7 +60,7 @@ public class RudderNetworkManager {
 
     void updateAnonymousIdHeaderString() {
         try {
-            this.anonymousIdHeaderString = Base64.encodeToString(RudderContext.getAnonymousId().getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);
+            this.anonymousIdHeaderString = Base64.encodeToString(RudderContext.getAnonymousId().getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
         } catch (Exception ex) {
             RudderLogger.logError(ex.getCause());
         }

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -20,8 +20,9 @@ android {
     buildToolsVersion "29.0.3"
     defaultConfig {
         applicationId "com.example.testapp1mg"
-        minSdkVersion 32
+        minSdkVersion 19
         targetSdkVersion 32
+        multiDexEnabled true
         versionCode 4
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
- Fix sourceConfig fetching issue which is caused because a newline is getting inserted on some devices due to the encoding mechanism we currently use. So we planned to fix that.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
