### PR TITLE
feat: added support for eliminating device_id from event

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
@@ -43,6 +43,8 @@ class Constants {
     static final long DEFAULT_SESSION_TIMEOUT = 300000;
     // default for automatic session tracking
     static final boolean AUTO_SESSION_TRACKING = true;
+    // default for collect deviceId
+    static final boolean COLLECT_DEVICE_ID = true;
     // default residency server
     static final RudderDataResidencyServer DATA_RESIDENCY_SERVER = RudderDataResidencyServer.US;
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -189,11 +189,11 @@ class EventRepository {
         // 2. initiate RudderElementCache
         if (preferenceManager.getOptStatus()) {
             RudderLogger.logDebug("User Opted out for tracking the activity, hence dropping the identifiers");
-            RudderElementCache.initiate(application, null, null, null, config.isAutoCollectAdvertId());
+            RudderElementCache.initiate(application, null, null, null, config.isAutoCollectAdvertId(), config.isCollectDeviceId());
         } else {
             // We first send the anonymousId to RudderElementCache which will just set the anonymousId static variable in RudderContext class.
             RudderElementCache.initiate(application, identifiers.anonymousId,
-                    identifiers.advertisingId, identifiers.deviceToken, config.isAutoCollectAdvertId());
+                    identifiers.advertisingId, identifiers.deviceToken, config.isAutoCollectAdvertId(), config.isCollectDeviceId());
         }
     }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderConfig.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderConfig.java
@@ -48,6 +48,7 @@ public class RudderConfig {
     private boolean trackAutoSession;
     private boolean useNewLifeCycleEvents;
     private boolean trackDeepLinks;
+    private boolean collectDeviceId;
     private long sessionTimeout;
     private String controlPlaneUrl;
     private List<RudderIntegration.Factory> factories;
@@ -73,6 +74,7 @@ public class RudderConfig {
                 Constants.AUTO_COLLECT_ADVERT_ID,
                 Constants.RECORD_SCREEN_VIEWS,
                 Constants.AUTO_SESSION_TRACKING,
+                Constants.COLLECT_DEVICE_ID,
                 Constants.DEFAULT_SESSION_TIMEOUT,
                 Constants.CONTROL_PLANE_URL,
                 null,
@@ -99,6 +101,7 @@ public class RudderConfig {
             boolean autoCollectAdvertId,
             boolean recordScreenViews,
             boolean trackAutoSession,
+            boolean collectDeviceId,
             long sessionTimeout,
             String controlPlaneUrl,
             List<RudderIntegration.Factory> factories,
@@ -187,6 +190,7 @@ public class RudderConfig {
             this.sessionTimeout = Constants.DEFAULT_SESSION_TIMEOUT;
         }
         this.trackAutoSession = trackAutoSession;
+        this.collectDeviceId = collectDeviceId;
 
         this.rudderDataResidencyServer = rudderDataResidencyServer;
         this.consentFilter = consentFilter;
@@ -344,6 +348,13 @@ public class RudderConfig {
      */
     public boolean isTrackAutoSession() {
         return trackAutoSession;
+    }
+
+    /**
+     * @return isCollectDeviceId (whether we want to collect the device ID)
+     */
+    public boolean isCollectDeviceId() {
+        return collectDeviceId;
     }
 
     /**
@@ -763,6 +774,17 @@ public class RudderConfig {
             return this;
         }
 
+        private boolean collectDeviceId = Constants.COLLECT_DEVICE_ID;
+
+        /**
+         * @param collectDeviceId (whether we are collecting the device ID)
+         * @return RudderConfig.Builder
+         */
+        public Builder withCollectDeviceId(boolean collectDeviceId) {
+            this.collectDeviceId = collectDeviceId;
+            return this;
+        }
+
         /**
          * Finalize your config building
          *
@@ -785,6 +807,7 @@ public class RudderConfig {
                     this.autoCollectAdvertId,
                     this.recordScreenViews,
                     this.autoSessionTracking,
+                    this.collectDeviceId,
                     this.sessionTimeout,
                     this.controlPlaneUrl,
                     this.factories,

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderContext.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderContext.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.rudderstack.android.sdk.core.util.Utils.isOnClassPath;
 
@@ -65,14 +66,19 @@ public class RudderContext {
         // cachedContext is used every time, once initialized
     }
 
-    RudderContext(Application application, String anonymousId, String advertisingId, String deviceToken) {
+    RudderContext(Application application, String anonymousId, String advertisingId, String deviceToken, boolean collectDeviceId) {
         RudderPreferenceManager preferenceManger = RudderPreferenceManager.getInstance(application);
 
         if (TextUtils.isEmpty(anonymousId)) {
-            anonymousId = preferenceManger.getAnonymousId() != null ? preferenceManger.getAnonymousId() : Utils.getDeviceId(application);
-        } else {
-            preferenceManger.saveAnonymousId(anonymousId);
+            anonymousId = preferenceManger.getAnonymousId();
+            if (anonymousId == null && collectDeviceId) {
+                anonymousId = Utils.getDeviceId(application);
+            }
+            if (anonymousId == null) {
+                anonymousId = UUID.randomUUID().toString();
+            }
         }
+        preferenceManger.saveAnonymousId(anonymousId);
 
         _anonymousId = anonymousId;
 
@@ -101,7 +107,7 @@ public class RudderContext {
 
         this.screenInfo = new RudderScreenInfo(application);
         this.userAgent = System.getProperty("http.agent");
-        this.deviceInfo = new RudderDeviceInfo(advertisingId, deviceToken);
+        this.deviceInfo = new RudderDeviceInfo(advertisingId, deviceToken, collectDeviceId);
         this.networkInfo = new RudderNetwork(application);
         this.osInfo = new RudderOSInfo();
         this.libraryInfo = new RudderLibraryInfo();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceInfo.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceInfo.java
@@ -11,8 +11,11 @@ import com.rudderstack.android.sdk.core.util.Utils;
 
 import static com.rudderstack.android.sdk.core.util.Utils.isOnClassPath;
 
+import androidx.annotation.Nullable;
+
 class RudderDeviceInfo {
     @SerializedName("id")
+    @Nullable
     private String deviceId;
     @SerializedName("manufacturer")
     private String manufacturer = Build.MANUFACTURER;
@@ -29,8 +32,10 @@ class RudderDeviceInfo {
     @SerializedName("advertisingId")
     private String advertisingId;
 
-    RudderDeviceInfo(String advertisingId, String token) {
-        this.deviceId = Utils.getDeviceId(RudderClient.getApplication());
+    RudderDeviceInfo(String advertisingId, String token, boolean collectDeviceId) {
+        if (collectDeviceId) {
+            this.deviceId = Utils.getDeviceId(RudderClient.getApplication());
+        }
         if (advertisingId != null && !advertisingId.isEmpty()) {
             this.advertisingId = advertisingId;
             this.adTrackingEnabled = true;
@@ -40,6 +45,7 @@ class RudderDeviceInfo {
         }
     }
 
+    @Nullable
     String getDeviceId() {
         return deviceId;
     }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderElementCache.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderElementCache.java
@@ -18,10 +18,10 @@ class RudderElementCache {
         // stop instantiating
     }
 
-    static void initiate(Application application, String anonymousId, String advertisingId, String deviceToken, boolean isAutoCollectAdvertId) {
+    static void initiate(Application application, String anonymousId, String advertisingId, String deviceToken, boolean isAutoCollectAdvertId, boolean isCollectDeviceId) {
         if (cachedContext == null) {
             RudderLogger.logDebug("RudderElementCache: initiating RudderContext");
-            cachedContext = new RudderContext(application, anonymousId, advertisingId, deviceToken);
+            cachedContext = new RudderContext(application, anonymousId, advertisingId, deviceToken, isCollectDeviceId);
             if (isAutoCollectAdvertId) {
                 cachedContext.updateDeviceWithAdId();
             }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -92,7 +92,6 @@ public class Utils {
         ) {
             return androidId;
         }
-        // If this still fails, generate random identifier that does not persist across installations
         return null;
     }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -82,6 +82,7 @@ public class Utils {
         return formatter.format(date);
     }
 
+    @Nullable
     public static String getDeviceId(Application application) {
         String androidId = getString(application.getContentResolver(), ANDROID_ID);
         if (!TextUtils.isEmpty(androidId)
@@ -92,7 +93,7 @@ public class Utils {
             return androidId;
         }
         // If this still fails, generate random identifier that does not persist across installations
-        return UUID.randomUUID().toString();
+        return null;
     }
 
     public static Map<String, Object> convertToMap(String json) {


### PR DESCRIPTION
**Fixes** #230 

Usage of deviceIds can be now be disabled through `RudderConfig.Builder().withCollectDeviceId(false);`;

DeviceId is now nullable so anonymous ids will be set to a random UUID string instead of basing it off the device id.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
