### PR TITLE
refactor(core): only apply publish and codecov if they exist

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,5 +64,9 @@ tasks.withType(JavaExec) {
 }
 //apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 
-apply from: rootProject.file('gradle/mvn-publish.gradle')
-apply from: rootProject.file('gradle/codecov.gradle')
+if (project.file('gradle/mvn-publish.gradle').exists()) {
+    apply from: rootProject.file('gradle/mvn-publish.gradle')
+}
+if (project.file('gradle/codecov.gradle').exists()) {
+    apply from: rootProject.file('gradle/codecov.gradle')
+}


### PR DESCRIPTION
Minor non-breaking change that allows a fork to easily substitute the :core module with their own implementation.
Useful e.g. when contributors are waiting for PRs to be merged.

Otherwise projects using forks would need to make empty files in their own projects which is ugly.