### PR TITLE
fix: moved db operations to background thread/executor and fixed leaking objects

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -20,8 +20,6 @@ import com.rudderstack.android.sdk.core.util.Utils;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-import com.rudderstack.android.sdk.core.util.Utils;
-
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.Collections;
@@ -31,10 +29,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
@@ -86,6 +80,7 @@ class DBPersistentManager extends SQLiteOpenHelper {
     private static final String DATABASE_COPY_EVENTS_FROM_OLD_TO_NEW = "INSERT INTO " + EVENTS_TABLE_NAME + "(" + DOWNGRADED_EVENTS_TABLE_COLUMNS + ") SELECT " + DOWNGRADED_EVENTS_TABLE_COLUMNS + " FROM " + OLD_EVENTS_TABLE;
     // command to drop the old events table
     private static final String DATABASE_DROP_OLD_EVENTS_TABLE = "DROP TABLE " + OLD_EVENTS_TABLE;
+    public static final String DBPERSISTENT_MANAGER_CHECK_FOR_MIGRATIONS_TAG = "DBPersistentManager: checkForMigrations: ";
 
     DBInsertionHandlerThread dbInsertionHandlerThread;
     final Queue<Message> queue = new LinkedList<>();
@@ -404,7 +399,7 @@ class DBPersistentManager extends SQLiteOpenHelper {
             }
         };
         // Need to perform db operations on a separate thread to support strict mode.
-        Future future = Executors.newSingleThreadExecutor().submit(runnable);
+        Future<?> future = Executors.newSingleThreadExecutor().submit(runnable);
         try {
             // todo: shall we add some timeout here ?
             future.get();
@@ -499,15 +494,15 @@ class DBPersistentManager extends SQLiteOpenHelper {
                 }
                 RudderLogger.logDebug("DBPersistentManager: checkForMigrations: Status column exists in the table already, hence no migration required");
             } catch (SQLiteDatabaseCorruptException ex) {
-                RudderLogger.logError("DBPersistentManager: checkForMigrations: " + ex.getLocalizedMessage());
+                RudderLogger.logError(DBPERSISTENT_MANAGER_CHECK_FOR_MIGRATIONS_TAG + ex.getLocalizedMessage());
             } catch (ConcurrentModificationException ex) {
-                RudderLogger.logError("DBPersistentManager: checkForMigrations: " + ex.getLocalizedMessage());
+                RudderLogger.logError(DBPERSISTENT_MANAGER_CHECK_FOR_MIGRATIONS_TAG + ex.getLocalizedMessage());
             } catch (NullPointerException ex) {
-                RudderLogger.logError("DBPersistentManager: checkForMigrations: " + ex.getLocalizedMessage());
+                RudderLogger.logError(DBPERSISTENT_MANAGER_CHECK_FOR_MIGRATIONS_TAG + ex.getLocalizedMessage());
             }
         };
         // Need to perform db operations on a separate thread to support strict mode.
-        Future future = Executors.newSingleThreadExecutor().submit(runnable);
+        Future<?> future = Executors.newSingleThreadExecutor().submit(runnable);
         try {
             // todo: shall we add some timeout here ?
             future.get();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/FlushUtils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/FlushUtils.java
@@ -45,10 +45,10 @@ class FlushUtils {
      */
     static boolean flushToServer(int flushQueueSize, String dataPlaneUrl, DBPersistentManager dbManager, RudderNetworkManager networkManager) {
         Result networkResponse;
+        final ArrayList<Integer> messageIds = new ArrayList<>();
+        final ArrayList<String> messages = new ArrayList<>();
+        RudderLogger.logDebug("FlushUtils: flush: Fetching events to flush to server");
         synchronized (MessageUploadLock.UPLOAD_LOCK) {
-            final ArrayList<Integer> messageIds = new ArrayList<>();
-            final ArrayList<String> messages = new ArrayList<>();
-            RudderLogger.logDebug("FlushUtils: flush: Fetching events to flush to server");
             dbManager.fetchAllCloudModeEventsFromDB(messageIds, messages);
             int numberOfBatches = getNumberOfBatches(messages.size(), flushQueueSize);
             RudderLogger.logDebug(String.format(Locale.US, "FlushUtils: flush: %d batches of events to be flushed", numberOfBatches));

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -37,13 +37,13 @@ public class RudderCloudModeManager {
                 final ArrayList<Integer> messageIds = new ArrayList<>();
                 final ArrayList<String> messages = new ArrayList<>();
                 while (true) {
+                    // clear lists for reuse
+                    messageIds.clear();
+                    messages.clear();
+                    result = null;
+                    maintainDBThreshold();
+                    RudderLogger.logDebug("CloudModeManager: cloudModeProcessor: Fetching events to flush to server");
                     synchronized (MessageUploadLock.UPLOAD_LOCK) {
-                        // clear lists for reuse
-                        messageIds.clear();
-                        messages.clear();
-                        result = null;
-                        maintainDBThreshold();
-                        RudderLogger.logDebug("CloudModeManager: cloudModeProcessor: Fetching events to flush to server");
                         dbManager.fetchCloudModeEventsFromDB(messageIds, messages, config.getFlushQueueSize());
                         if (messages.size() >= config.getFlushQueueSize() || (!messages.isEmpty() && sleepCount >= config.getSleepTimeOut())) {
                             // form payload JSON form the list of messages

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
@@ -212,6 +212,8 @@ public class RudderNetworkManager {
         while ((res = bis.read()) != -1) {
             baos.write((byte) res);
         }
+        bis.close();
+        baos.close();
         return baos.toString();
     }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
@@ -112,86 +112,101 @@ public class RudderNetworkManager {
             synchronized (MessageUploadLock.REQUEST_LOCK) {
                 httpConnection.connect();
             }
-
             return getResult(httpConnection);
         } catch (Exception ex) {
-            RudderLogger.logError(ex);
+            RudderLogger.logError("RudderNetworkManager: sendNetworkRequest: Exception occurred while sending the request to " + requestURL + ex.getLocalizedMessage());
             return new Result(NetworkResponses.ERROR, -1, null, ex.getLocalizedMessage());
         }
     }
 
-    private Result getResult(HttpURLConnection httpConnection) throws IOException {
+    private Result getResult(HttpURLConnection httpConnection) {
         String responsePayload = null;
         String errorPayload = null;
         NetworkResponses networkResponse = null;
 
-        int responseCode = httpConnection.getResponseCode();
-        if (responseCode == 200) {
-            responsePayload = getResponse(httpConnection.getInputStream());
-            RudderLogger.logInfo(String.format(Locale.US, "RudderNetworkManager: sendNetworkRequest: Request to endpoint %s was successful with status code %d and response is %s",
-                    httpConnection.getURL(), responseCode, responsePayload));
-            networkResponse = NetworkResponses.SUCCESS;
+        int responseCode = 0;
+        try {
+            responseCode = httpConnection.getResponseCode();
+            if (responseCode == 200) {
+                responsePayload = getResponse(httpConnection.getInputStream());
+                RudderLogger.logInfo(String.format(Locale.US, "RudderNetworkManager: sendNetworkRequest: Request to endpoint %s was successful with status code %d and response is %s",
+                        httpConnection.getURL(), responseCode, responsePayload));
+                networkResponse = NetworkResponses.SUCCESS;
 
-        } else {
-            errorPayload = getResponse(httpConnection.getErrorStream());
-            RudderLogger.logError(String.format(Locale.US, "RudderNetworkManager: sendNetworkRequest: Request to endpoint %s failed with status code %d and error %s",
-                    httpConnection.getURL(), responseCode, errorPayload));
-            if (errorPayload.toLowerCase().contains("invalid write key"))
-                networkResponse = NetworkResponses.WRITE_KEY_ERROR;
-            if (responseCode == 404)
-                networkResponse = NetworkResponses.RESOURCE_NOT_FOUND;
+            } else {
+                errorPayload = getResponse(httpConnection.getErrorStream());
+                RudderLogger.logError(String.format(Locale.US, "RudderNetworkManager: sendNetworkRequest: Request to endpoint %s failed with status code %d and error %s",
+                        httpConnection.getURL(), responseCode, errorPayload));
+                if (errorPayload != null && errorPayload.toLowerCase().contains("invalid write key"))
+                    networkResponse = NetworkResponses.WRITE_KEY_ERROR;
+                if (responseCode == 404)
+                    networkResponse = NetworkResponses.RESOURCE_NOT_FOUND;
+            }
+            // if networkresponse is null (or) if both response and error payload is null, then it is an error
+            if (networkResponse == null || (responsePayload == null && errorPayload == null))
+                networkResponse = NetworkResponses.ERROR;
+            return new Result(networkResponse, responseCode, responsePayload, errorPayload);
+        } catch (Exception ex) {
+            RudderLogger.logError("RudderNetworkManager: sendNetworkRequest: Exception occurred while getting the response from the request to " + httpConnection.getURL() + ex.getLocalizedMessage());
+            return new Result(NetworkResponses.ERROR, responseCode, responsePayload, ex.getLocalizedMessage());
+        } finally {
+            httpConnection.disconnect();
         }
-        return new Result(networkResponse == null ? NetworkResponses.ERROR : networkResponse, responseCode, responsePayload, errorPayload);
     }
 
     private HttpURLConnection updateHttpConnection(String requestURL, RequestMethod requestMethod,
-                                                   String requestPayload, boolean isDMTRequest, boolean isGzipSupported)
-            throws IOException {
-        URL url = new URL(requestURL);
-        RudderLogger.logDebug(String.format(Locale.US, "RudderNetworkManager: sendNetworkRequest: Request URL: %s", requestURL));
-        HttpURLConnection httpConnection = (HttpURLConnection) url.openConnection();
-        if (isGzipSupported && isGzipConfigured) {
-            RudderLogger.logDebug("RudderNetworkManager: sendNetworkRequest: Gzip is enabled");
-            Map<String, String> customRequestHeaders = new HashMap<>();
-            customRequestHeaders.put("Content-Encoding", "gzip");
-            return updateHttpConnection(httpConnection, requestMethod, requestPayload, isDMTRequest, customRequestHeaders,
-                    GzipUtils::getGzipOutputStream);
+                                                   String requestPayload, boolean isDMTRequest, boolean isGzipSupported) {
+        try {
+            URL url = new URL(requestURL);
+            RudderLogger.logDebug(String.format(Locale.US, "RudderNetworkManager: sendNetworkRequest: Request URL: %s", requestURL));
+            HttpURLConnection httpConnection = (HttpURLConnection) url.openConnection();
+            if (isGzipSupported && isGzipConfigured) {
+                RudderLogger.logDebug("RudderNetworkManager: sendNetworkRequest: Gzip is enabled");
+                Map<String, String> customRequestHeaders = new HashMap<>();
+                customRequestHeaders.put("Content-Encoding", "gzip");
+                return updateHttpConnection(httpConnection, requestMethod, requestPayload, isDMTRequest, customRequestHeaders,
+                        GzipUtils::getGzipOutputStream);
+            }
+            return updateHttpConnection(httpConnection, requestMethod, requestPayload, isDMTRequest,
+                    null, null);
+        } catch (Exception ex) {
+            RudderLogger.logError("RudderNetworkManager: sendNetworkRequest: Exception occurred while creating HttpURLConnection" + ex.getLocalizedMessage());
+            return null;
         }
-        return updateHttpConnection(httpConnection, requestMethod, requestPayload, isDMTRequest,
-                null, null);
     }
 
     @VisibleForTesting
     HttpURLConnection updateHttpConnection(HttpURLConnection httpConnection, RequestMethod requestMethod,
                                            String requestPayload, boolean isDMTRequest,
                                            @Nullable Map<String, String> customRequestHeaders,
-                                           @Nullable FunctionUtils.Function<OutputStream, OutputStream> connectionWrapperOSGenerator) throws IOException {
-        httpConnection.setRequestProperty("Authorization", String.format(Locale.US, "Basic %s", authHeaderString));
-        if (requestMethod == RequestMethod.GET) {
-            httpConnection.setRequestMethod("GET");
-        } else {
-            httpConnection.setDoOutput(true);
-            httpConnection.setRequestMethod("POST");
-            httpConnection.setRequestProperty("Content-Type", "application/json");
-            httpConnection.setRequestProperty("AnonymousId", anonymousIdHeaderString);
-            if (customRequestHeaders != null && !customRequestHeaders.isEmpty()) {
-                for (Map.Entry<String, String> entry : customRequestHeaders.entrySet()) {
-                    httpConnection.setRequestProperty(entry.getKey(), entry.getValue());
+                                           @Nullable FunctionUtils.Function<OutputStream, OutputStream> connectionWrapperOSGenerator) {
+        try (OutputStream os = httpConnection.getOutputStream();
+             OutputStream oss = connectionWrapperOSGenerator != null ? connectionWrapperOSGenerator.apply(os) : null;
+             OutputStreamWriter osw = new OutputStreamWriter(oss != null ? oss : os, StandardCharsets.UTF_8);
+        ) {
+            httpConnection.setRequestProperty("Authorization", String.format(Locale.US, "Basic %s", authHeaderString));
+            if (requestMethod == RequestMethod.GET) {
+                httpConnection.setRequestMethod("GET");
+            } else {
+                httpConnection.setDoOutput(true);
+                httpConnection.setRequestMethod("POST");
+                httpConnection.setRequestProperty("Content-Type", "application/json");
+                httpConnection.setRequestProperty("AnonymousId", anonymousIdHeaderString);
+                if (customRequestHeaders != null && !customRequestHeaders.isEmpty()) {
+                    for (Map.Entry<String, String> entry : customRequestHeaders.entrySet()) {
+                        httpConnection.setRequestProperty(entry.getKey(), entry.getValue());
+                    }
                 }
+                String requestPayloadWithMetadata = withAddedMetadataToRequestPayload(requestPayload, isDMTRequest);
+                osw.write(requestPayloadWithMetadata);
+                osw.flush();
             }
-            String requestPayloadWithMetadata = withAddedMetadataToRequestPayload(requestPayload, isDMTRequest);
-            OutputStream os = httpConnection.getOutputStream();
-            if (connectionWrapperOSGenerator != null) {
-                os = connectionWrapperOSGenerator.apply(os);
-                System.out.println("RudderNetworkManager: sendNetworkRequest: Gzip is enabled");
-            }
-            OutputStreamWriter osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
-            osw.write(requestPayloadWithMetadata);
-            osw.flush();
-            osw.close();
-            os.close();
+            return httpConnection;
+        } catch (Exception ex) {
+            RudderLogger.logError("RudderNetworkManager: updateHttpConnection: Error while updating the http connection" + ex.getLocalizedMessage());
+            return null;
         }
-        return httpConnection;
+
     }
 
     @VisibleForTesting
@@ -205,16 +220,18 @@ public class RudderNetworkManager {
         return jsonObject.toString();
     }
 
-    private String getResponse(InputStream stream) throws IOException {
-        BufferedInputStream bis = new BufferedInputStream(stream);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        int res;
-        while ((res = bis.read()) != -1) {
-            baos.write((byte) res);
+    private String getResponse(InputStream stream) {
+        try (BufferedInputStream bis = new BufferedInputStream(stream);
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            int res;
+            while ((res = bis.read()) != -1) {
+                baos.write((byte) res);
+            }
+            return baos.toString();
+        } catch (Exception ex) {
+            RudderLogger.logError("RudderNetworkManager: getResponse: Exception occurred while reading response" + ex.getLocalizedMessage());
+            return null;
         }
-        bis.close();
-        baos.close();
-        return baos.toString();
     }
 
     static String addEndPoint(String url, String endPoint) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
@@ -179,14 +179,14 @@ public class RudderNetworkManager {
                     httpConnection.setRequestProperty(entry.getKey(), entry.getValue());
                 }
             }
-            requestPayload = withAddedMetadataToRequestPayload(requestPayload, isDMTRequest);
+            String requestPayloadWithMetadata = withAddedMetadataToRequestPayload(requestPayload, isDMTRequest);
             OutputStream os = httpConnection.getOutputStream();
             if (connectionWrapperOSGenerator != null) {
                 os = connectionWrapperOSGenerator.apply(os);
                 System.out.println("RudderNetworkManager: sendNetworkRequest: Gzip is enabled");
             }
             OutputStreamWriter osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
-            osw.write(requestPayload);
+            osw.write(requestPayloadWithMetadata);
             osw.flush();
             osw.close();
             os.close();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
@@ -109,6 +109,9 @@ public class RudderNetworkManager {
 
         try {
             HttpURLConnection httpConnection = updateHttpConnection(requestURL, requestMethod, requestPayload, isDMTRequest, isGzipAvailableForApi);
+            if (httpConnection == null) {
+                return new Result(NetworkResponses.ERROR, -1, null, "Http Connection is Null");
+            }
             synchronized (MessageUploadLock.REQUEST_LOCK) {
                 httpConnection.connect();
             }


### PR DESCRIPTION
## Fixes

* Moved db operations related to migration to an executor which executes them on a background thread
* Closed leaking cursor object returned on checking if a status column exists
* Closed the input and output streams opened when reading the response of HTTP Connection
* Used try with resources wherever possible to close the auto-closeable
* Reduced the length of code in synchronized blocks for better performance
* Stopped bubbling up of exceptions in RudderNetworkManager

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
