### PR TITLE
fix: replay message queue dumping logic

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -70,7 +70,7 @@ class DBPersistentManager extends SQLiteOpenHelper {
 
     private static final String SET_STATUS_FOR_EXISTING = "UPDATE " + EVENTS_TABLE_NAME + " SET " + STATUS_COL + " = " + STATUS_DEVICE_MODE_DONE;
     private static final String SET_DM_PROCESSED_AND_STATUS_FOR_EXISTING = "UPDATE " + EVENTS_TABLE_NAME +
-            " SET " + DM_PROCESSED_COL + " = '" + STATUS_DONE + "'" +
+            " SET " + DM_PROCESSED_COL + " = " + STATUS_DONE +
             ", " + STATUS_COL + " = " + STATUS_DEVICE_MODE_DONE;
 
     static final String BACKSLASH = "\\\\'";

--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -590,7 +590,7 @@ class DBPersistentManager extends SQLiteOpenHelper {
         String rowIdsCSVString = Utils.getCSVString(rowIds);
         if (rowIdsCSVString == null) return;
         String sql = "UPDATE " + DBPersistentManager.EVENTS_TABLE_NAME + " SET " +
-                DBPersistentManager.STATUS_COL + " = " + DBPersistentManager.STATUS_DEVICE_MODE_DONE +
+                DBPersistentManager.STATUS_COL + " = " + "(" + DBPersistentManager.STATUS_COL + " | " + DBPersistentManager.STATUS_DEVICE_MODE_DONE + ")" +
                 ", " + DBPersistentManager.DM_PROCESSED_COL + " = " + DBPersistentManager.DM_PROCESSED_DONE +
                 " WHERE " + MESSAGE_ID_COL + " IN "
                 + rowIdsCSVString + ";";

--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -443,10 +443,7 @@ class DBPersistentManager extends SQLiteOpenHelper {
 
     @Override
     public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        if (checkIfColumnExists(db, STATUS_COL) || checkIfColumnExists(db, DM_PROCESSED_COL)) {
-            RudderLogger.logDebug(String.format(Locale.US, "DBPersistentManager: onDowngrade: DB got downgraded from version: %d to the version: %d, hence running migration to remove the status and dm_processed columns", oldVersion, newVersion));
-            deleteStatusAndDMProcessedColumns(db);
-        }
+        // We have decided not to implement this method currently
     }
 
     private void deleteStatusAndDMProcessedColumns(SQLiteDatabase database) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -535,17 +535,6 @@ class DBPersistentManager extends SQLiteOpenHelper {
         }
     }
 
-    public void updateDeviceModeEventsStatus() {
-        String sql = "UPDATE " + DBPersistentManager.EVENTS_TABLE_NAME + " SET " +
-                DBPersistentManager.STATUS_COL + " = (" + DBPersistentManager.STATUS_COL + " | " + DBPersistentManager.STATUS_DEVICE_MODE_DONE +
-                ") WHERE " + DBPersistentManager.STATUS_COL + " IN " + "(" + DBPersistentManager.STATUS_NEW + ", " +
-                DBPersistentManager.STATUS_CLOUD_MODE_DONE + ")";
-        synchronized (DB_LOCK) {
-            getWritableDatabase().execSQL(sql);
-        }
-    }
-
-
     void markDeviceModeDone(List<Integer> rowIds) {
         String rowIdsCSVString = Utils.getCSVString(rowIds);
         if (rowIdsCSVString == null) return;

--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -72,7 +72,7 @@ class DBPersistentManager extends SQLiteOpenHelper {
     private static final String SET_STATUS_FOR_EXISTING = "UPDATE " + EVENTS_TABLE_NAME + " SET " + STATUS_COL + " = " + STATUS_DEVICE_MODE_DONE;
     private static final String SET_DM_PROCESSED_AND_STATUS_FOR_EXISTING = "UPDATE " + EVENTS_TABLE_NAME +
             " SET " + DM_PROCESSED_COL + " = " + DM_PROCESSED_DONE +
-            ", " + STATUS_COL + " = " + STATUS_DEVICE_MODE_DONE;
+            ", " + STATUS_COL + " = (" + STATUS_COL + " | " + STATUS_DEVICE_MODE_DONE + ") ";
 
     static final String BACKSLASH = "\\\\'";
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -137,24 +137,9 @@ class EventRepository {
             this.applicationLifeCycleManager.trackApplicationUpdateStatus();
 
             initializeLifecycleTracking(applicationLifeCycleManager);
-
-            // Previously in certain cases (e.g., network unavailability) events are not processed by device mode factories and statuses remains at either 0 or 2.
-            // Now we are marking those events as device_mode_processing_done.
-            if (isPreviousEventsDeletionAllowed()) {
-                dbManager.updateDeviceModeEventsStatus();
-                dbManager.runGcForEvents();
-            }
         } catch (Exception ex) {
             RudderLogger.logError(ex.getCause());
         }
-    }
-
-    private boolean isPreviousEventsDeletionAllowed() {
-        if (!preferenceManager.getEventDeletionStatus()) {
-            preferenceManager.saveEventDeletionStatus();
-            return this.applicationLifeCycleManager.isApplicationUpdated();
-        }
-        return false;
     }
 
     private void initializeLifecycleTracking(ApplicationLifeCycleManager applicationLifeCycleManager) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceModeManager.java
@@ -204,14 +204,15 @@ public class RudderDeviceModeManager {
      *  a. before initialization
      *   Events are stored with status new in database.
      *  b. after initialization
-     *   Since areFactoriesInitialized is true, replayMessageQueue is called, device mode events are
-     *   dumped appropiately and marked as device_mode_done
+     *   Since areDeviceModeFactoriesAbsent is true, replayMessageQueue is called, device mode events are
+     *   dumped appropriately and marked as device_mode_done
      * 2. Device Modes are present.
      *  a. With transformations
      *      i. before initialization
      *       As usual saved in db.
      *      ii. after initialization
-     *      They are polled from db, transformed, sent to device modes.
+     *      replayMessageQueue is called which fetches events are polled from db, mark them as dm_processed status done,
+     *      and send it to eligible device mode destinations without transformation
      *  b. Without transformations
      *      i. before initialization
      *       Saved to DB
@@ -224,7 +225,9 @@ public class RudderDeviceModeManager {
         List<Integer> messageIds = new ArrayList<>();
         List<String> messages = new ArrayList<>();
         do {
-            dbPersistentManager.fetchDeviceModeEventsFromDb(messageIds, messages, MAX_FLUSH_QUEUE_SIZE);
+            messages.clear();
+            messageIds.clear();
+            dbPersistentManager.fetchDeviceModeEventsWithPendingStatusFromDb(messageIds, messages, MAX_FLUSH_QUEUE_SIZE);
             RudderLogger.logDebug(String.format(Locale.US, "RudderDeviceModeManager: replayMessageQueue: replaying old messages with factories. Count: %d", messageIds.size()));
             for (int i = 0; i < messageIds.size(); i++) {
                 try {
@@ -234,28 +237,42 @@ public class RudderDeviceModeManager {
                     RudderLogger.logError(String.format(Locale.US, "RudderDeviceModeManager: replayMessageQueue: Exception in dumping message %s due to %s", messages.get(i), e.getMessage()));
                 }
             }
-        }while (dbPersistentManager.getDeviceModeRecordCount() > 0);
+        } while (dbPersistentManager.getDeviceModeRecordCount() > 0 && !messageIds.isEmpty());
     }
 
     void makeFactoryDump(RudderMessage message, Integer rowId, boolean fromHistory) {
-        if (this.areDeviceModeFactoriesAbsent) {
-            dbPersistentManager.markDeviceModeDone(Arrays.asList(rowId));
-        } else if (areFactoriesInitialized || fromHistory) {
-            List<String> eligibleDestinations = getEligibleDestinations(message);
-
-            List<String> destinationsWithTransformations = getDestinationsWithTransformationStatus(TRANSFORMATION_STATUS.ENABLED, eligibleDestinations);
-            if (destinationsWithTransformations.isEmpty()) {
-                RudderLogger.logVerbose(String.format(Locale.US, "RudderDeviceModeManager: makeFactoryDump: Marking event with rowId %s as DEVICE_MODE_PROCESSING DONE as it has no device mode destinations with transformations", rowId));
-                dbPersistentManager.markDeviceModeDone(Arrays.asList(rowId));
-            } else {
-                for (String destinationName : destinationsWithTransformations) {
-                    RudderLogger.logDebug(String.format(Locale.US, "RudderDeviceModeManager: makeFactoryDump: Destination %s needs transformation, hence the event will be batched and sent to transformation service", destinationName));
-                }
+        synchronized (this) {
+            if (this.areDeviceModeFactoriesAbsent) {
+                markDeviceModeStatusDone(rowId);
+            } else if (areFactoriesInitialized || fromHistory) {
+                List<String> eligibleDestinations = getEligibleDestinations(message);
+                updateMessageStatusBasedOnTransformations(eligibleDestinations, rowId, message);
+                dumpMessageToDestinationWithoutTransformation(eligibleDestinations, message);
             }
-
-            List<String> destinationsWithoutTransformations = getDestinationsWithTransformationStatus(TRANSFORMATION_STATUS.DISABLED, eligibleDestinations);
-            dumpEventToDestinations(message, destinationsWithoutTransformations, "makeFactoryDump");
         }
+    }
+
+    private void markDeviceModeStatusDone(int rowId) {
+        RudderLogger.logVerbose(String.format(Locale.US, "RudderDeviceModeManager: markDeviceModeDone: Marking event with rowId %s as DEVICE_MODE_PROCESSING DONE", rowId));
+        dbPersistentManager.markDeviceModeDone(Arrays.asList(rowId));
+    }
+
+    private void updateMessageStatusBasedOnTransformations(List<String> eligibleDestinations, int rowId, RudderMessage message) {
+        List<String> destinationsWithTransformations = getDestinationsWithTransformationStatus(TRANSFORMATION_STATUS.ENABLED, eligibleDestinations);
+        if (destinationsWithTransformations.isEmpty()) {
+            markDeviceModeStatusDone(rowId);
+        } else {
+            for (String destinationName : destinationsWithTransformations) {
+                RudderLogger.logDebug(String.format(Locale.US, "RudderDeviceModeManager: updateMessageStatusBasedOnTransformations: Destination %s needs transformation, hence the event will be batched and sent to transformation service", destinationName));
+            }
+            dbPersistentManager.markDeviceModeProcessedDone(rowId);
+            RudderLogger.logVerbose(String.format(Locale.US, "RudderDeviceModeManager: updateMessageStatusBasedOnTransformations: marking event: %s, dm_processed status as DONE", message.getEventName()));
+        }
+    }
+
+    private void dumpMessageToDestinationWithoutTransformation(List<String> eligibleDestinations, RudderMessage message) {
+        List<String> destinationsWithoutTransformations = getDestinationsWithTransformationStatus(TRANSFORMATION_STATUS.DISABLED, eligibleDestinations);
+        dumpEventToDestinations(message, destinationsWithoutTransformations, "makeFactoryDump");
     }
 
     /**

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderPreferenceManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderPreferenceManager.java
@@ -27,7 +27,6 @@ class RudderPreferenceManager {
     private static final String RUDDER_SESSION_ID_KEY = "rl_session_id_key";
     private static final String RUDDER_AUTO_SESSION_TRACKING_STATUS_KEY = "rl_auto_session_tracking_status_key";
     private static final String RUDDER_DMT_HEADER_KEY = "rl_dmt_header_key";
-    private static final String RUDDER_EVENT_DELETION_STATUS_KEY = "rl_event_deletion_status_key";
 
     private static SharedPreferences preferences;
     private static RudderPreferenceManager instance;
@@ -191,13 +190,5 @@ class RudderPreferenceManager {
     @Nullable
     String getAuthToken() {
         return preferences.getString(RUDDER_DMT_HEADER_KEY, null);
-    }
-
-    void saveEventDeletionStatus() {
-        preferences.edit().putBoolean(RUDDER_EVENT_DELETION_STATUS_KEY, true).apply();
-    }
-
-    boolean getEventDeletionStatus() {
-        return preferences.getBoolean(RUDDER_EVENT_DELETION_STATUS_KEY, false);
     }
 }


### PR DESCRIPTION
**Fixes** # (*issue*)

- This update addresses the replayMessageQueue dumping logic. Starting from this version, whenever the app is started or immediately after the Rudder SDK initialization, all the previous events that are pending to be sent to the device mode factories will be retrieved from the database and dumped.
- Additionally, with the first update using this fixed version, any remaining previous events will be marked as `device_mode_processing_done.` This ensures that any past events will not be dumped to device mode factories anymore.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
