### PR TITLE
fix: sdk 400 ensure empty key is not accepted as encryption key for

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
@@ -160,7 +160,7 @@ public class RudderClient {
 
     private static void initiateRudderReporter(Context context, @Nullable String writeKey) {
         String writeKeyOrBlank = writeKey == null ? "" : writeKey;
-        if (rudderReporter == null) {
+        if (rudderReporter == null && context.getResources() != null) {
             rudderReporter = new DefaultRudderReporter(context, METRICS_URL_PROD,
                     new Configuration(new LibraryMetadata(
                             BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE, writeKeyOrBlank

--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProvider.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProvider.java
@@ -115,11 +115,11 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
         SQLiteDatabase.loadLibs(application);
     }
 
-    private boolean deleteEncryptedDb() {
+    private void deleteEncryptedDb() {
         File encryptedDb = application.getDatabasePath(params.encryptedDbName);
-        if (encryptedDb.exists())
-            return encryptedDb.delete();
-        return false;
+        if (encryptedDb.exists()) {
+            deleteFile(encryptedDb);
+        }
     }
 
     private void migrateToDefaultDatabase(File databasePath) {
@@ -134,7 +134,13 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
         database.rawExecSQL("select sqlcipher_export('rl_persistence')");
         database.rawExecSQL("DETACH DATABASE rl_persistence");
         database.close();
-        encryptedDb.delete();// No-Op
+        deleteFile(encryptedDb);
+    }
+
+    private void deleteFile(File encryptedDb) {
+        if (!encryptedDb.delete()) {
+            RudderLogger.logError("Unable to delete database " + encryptedDb.getAbsolutePath());
+        }
     }
 
 
@@ -149,7 +155,7 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
         database.rawExecSQL("select sqlcipher_export('rl_persistence_encrypted')");
         database.rawExecSQL("DETACH DATABASE rl_persistence_encrypted");
         database.close();
-        decryptedDb.delete(); //No-Op
+        deleteFile(decryptedDb);
 
     }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProvider.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProvider.java
@@ -46,7 +46,8 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
 
     @Override
     public Persistence get(Persistence.DbCreateListener dbCreateListener) {
-        if (!params.isEncrypted) {
+        if (!params.isEncrypted
+                || params.encryptionKey == null || params.encryptedDbName == null) {
             return getDefaultPersistence(dbCreateListener);
         } else {
             return getEncryptedPersistence(dbCreateListener);
@@ -61,7 +62,7 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
         if (!checkDatabaseExists(params.encryptedDbName)
                 && checkDatabaseExists(params.dbName)) {
             migrateToEncryptedDatabase(encryptedDbPath);
-        }else {
+        } else {
             if (!checkIfEncryptionIsValid(encryptedDbPath))
                 deleteEncryptedDb();             //drop database
         }
@@ -72,7 +73,7 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
     private EncryptedPersistence createEncryptedObject(@Nullable Persistence.DbCreateListener dbCreateListener) {
         return new EncryptedPersistence(application,
                 new EncryptedPersistence.DbParams(params.encryptedDbName,
-                params.dbVersion, params.encryptionKey), dbCreateListener);
+                        params.dbVersion, params.encryptionKey), dbCreateListener);
     }
 
 
@@ -94,7 +95,7 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
                 checkDatabaseExists(params.encryptedDbName)) {
             initCipheredDatabase();
             createDefaultDatabase();
-            try{
+            try {
                 migrateToDefaultDatabase(application.getDatabasePath(params.dbName));
             } catch (Exception e) {
                 RudderLogger.logError("Encryption key is invalid: Dumping the database and constructing a new unencrypted one");
@@ -126,13 +127,14 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
         File encryptedDb = application.getDatabasePath(params.encryptedDbName);
         String encryptedPath = encryptedDb.getAbsolutePath();
         SQLiteDatabase database = SQLiteDatabase.openDatabase(encryptedPath, params.encryptionKey, null, SQLiteDatabase.OPEN_READWRITE);
+        //will throw exception if encryption key is invalid
         database.isDatabaseIntegrityOk();
         database.rawExecSQL(String.format("ATTACH DATABASE '%s' AS rl_persistence KEY ''",
                 databasePath.getAbsolutePath()));
         database.rawExecSQL("select sqlcipher_export('rl_persistence')");
         database.rawExecSQL("DETACH DATABASE rl_persistence");
         database.close();
-        encryptedDb.delete();
+        encryptedDb.delete();// No-Op
     }
 
 
@@ -147,13 +149,13 @@ public class DefaultPersistenceProvider implements PersistenceProvider {
         database.rawExecSQL("select sqlcipher_export('rl_persistence_encrypted')");
         database.rawExecSQL("DETACH DATABASE rl_persistence_encrypted");
         database.close();
-        decryptedDb.delete();
+        decryptedDb.delete(); //No-Op
 
     }
 
 
-    private boolean checkDatabaseExists(String dbName) {
-        return application.getDatabasePath(dbName).exists();
+    private boolean checkDatabaseExists(@Nullable String dbName) {
+        return dbName != null && application.getDatabasePath(dbName).exists();
     }
 
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProviderFactory.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProviderFactory.java
@@ -48,9 +48,10 @@ public class DefaultPersistenceProviderFactory implements PersistenceProvider.Fa
         }
         if (isEncrypted) {
             if (encryptionKey == null) {
-                RudderLogger.logWarn("DBPersistentManager: isEncrypted is true but encryptionKey is null. Proceeding with null key");
+                RudderLogger.logWarn("DBPersistentManager: isEncrypted is true but encryptionKey is null. Proceeding with unencrypted database");
+                isEncrypted = false;
             }
-            if (encryptedDbName == null) {
+            else if (encryptedDbName == null) {
                 RudderLogger.logError("DBPersistentManager: isEncrypted is true but encryptedDbName is null. Aborting Db creation");
                 return null;
             }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProviderFactory.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistenceProviderFactory.java
@@ -1,6 +1,7 @@
 package com.rudderstack.android.sdk.core.persistence;
 
 import android.app.Application;
+import android.text.TextUtils;
 
 import com.rudderstack.android.sdk.core.RudderLogger;
 
@@ -47,8 +48,8 @@ public class DefaultPersistenceProviderFactory implements PersistenceProvider.Fa
             dbVersion = 1;
         }
         if (isEncrypted) {
-            if (encryptionKey == null) {
-                RudderLogger.logWarn("DBPersistentManager: isEncrypted is true but encryptionKey is null. Proceeding with unencrypted database");
+            if (TextUtils.isEmpty(encryptionKey)) {
+                RudderLogger.logWarn("DBPersistentManager: isEncrypted is true but encryptionKey is null or empty. Proceeding with unencrypted database");
                 isEncrypted = false;
             }
             else if (encryptedDbName == null) {


### PR DESCRIPTION
**Fixes** # (*issue*)
Null or empty encryption key is not valid anymore. In case of null or empty key, the database is no longer encrypted.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
