### PR TITLE
fix: sessionId not getting cleared issue

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
@@ -41,7 +41,7 @@ public class RudderUserSessionManager {
         if (userSession.getSessionId() != null) {
             message.setSession(userSession);
         }
-        if (config.isTrackLifecycleEvents() && config.isTrackAutoSession()) {
+        if (isAutomaticSessionTrackingEnabled()) {
             userSession.updateLastEventTimeStamp();
         }
     }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
@@ -17,14 +17,23 @@ public class RudderUserSessionManager {
         // 8. clear session if automatic session tracking was enabled previously
         // but disabled presently or vice versa.
         boolean previousAutoSessionTrackingStatus = preferenceManager.getAutoSessionTrackingStatus();
-        if (previousAutoSessionTrackingStatus != config.isTrackAutoSession()) {
+        boolean currentAutomaticSessionTrackingStatus = isAutomaticSessionTrackingEnabled();
+        if (previousAutoSessionTrackingStatus != currentAutomaticSessionTrackingStatus) {
             userSession.clearSession();
         }
-        preferenceManager.saveAutoSessionTrackingStatus(config.isTrackAutoSession());
+        preferenceManager.saveAutoSessionTrackingStatus(currentAutomaticSessionTrackingStatus);
         // starting automatic session tracking if enabled.
-        if (config.isTrackLifecycleEvents() && config.isTrackAutoSession()) {
+        if (currentAutomaticSessionTrackingStatus) {
             userSession.startSessionIfNeeded();
         }
+    }
+
+    private boolean isAutomaticSessionTrackingEnabled() {
+        return config.isTrackAutoSession() && isAutomaticLifeCycleEnabled();
+    }
+
+    private boolean isAutomaticLifeCycleEnabled() {
+        return config.isTrackLifecycleEvents() || config.isNewLifeCycleEvents();
     }
 
     void applySessionTracking(RudderMessage message) {


### PR DESCRIPTION
## Description

- Fix the logic to clear the `sessionId`, when it is changed from on to off.
- Make session logic dependent upon the `withNewLifecycleEvents` API, along with old lifecycle and session tracking API's.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
