### PR TITLE
fix: typo in sample-kotlin build.gradle

### DIFF
--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -28,7 +28,7 @@ android {
         versionCode 4
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "DATA_PLANE_URL", properties.getProperty('dataplaneUrl', 'https://api.rudderstack.com'))
+        buildConfigField("String", "DATA_PLANE_URL", properties.getProperty('dataplaneUrl',  "\"https://api.rudderstack.com\""))
         buildConfigField("String", "CONTROL_PLANE_URL", properties.getProperty('controlplaneUrl', "\"https://api.rudderstack.com\""))
         buildConfigField("String", "WRITE_KEY", properties.getProperty('writeKey', "\"\""))
     }


### PR DESCRIPTION
## Bugfix
This PR fixes a bug in the `sample-kotlin `app of the `rudder-sdk-android` project and in which the `sample-kotlin` app could not being built because of a typo change in the build.gradle build config properties.

The change replaces `' `to `"` in order to be compiled correctly regardless JAVA versions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
