### PR TITLE
fix: update lastActiveTimestamp value when reset call is made

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderPreferenceManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderPreferenceManager.java
@@ -27,7 +27,7 @@ class RudderPreferenceManager {
     private static final String RUDDER_OPT_OUT_TIME_KEY = "rl_opt_out_time";
     private static final String RUDDER_ANONYMOUS_ID_KEY = "rl_anonymous_id_key";
     private static final String RUDDER_PERIODIC_WORK_REQUEST_ID_KEY = "rl_periodic_work_request_key";
-    private static final String RUDDER_LAST_EVENT_TIMESTAMP_KEY = "rl_last_event_timestamp_key";
+    private static final String RUDDER_LAST_ACTIVE_TIMESTAMP_KEY = "rl_last_event_timestamp_key";
     private static final String RUDDER_SESSION_ID_KEY = "rl_session_id_key";
     private static final String RUDDER_AUTO_SESSION_TRACKING_STATUS_KEY = "rl_auto_session_tracking_status_key";
     private static final String RUDDER_DMT_HEADER_KEY = "rl_dmt_header_key";
@@ -157,18 +157,18 @@ class RudderPreferenceManager {
         return preferences.getLong(RUDDER_OPT_OUT_TIME_KEY, -1);
     }
 
-    void saveLastEventTimeStamp(Long time) {
-        preferences.edit().putLong(RUDDER_LAST_EVENT_TIMESTAMP_KEY, time).apply();
+    void saveLastActiveTimestamp(Long time) {
+        preferences.edit().putLong(RUDDER_LAST_ACTIVE_TIMESTAMP_KEY, time).apply();
     }
 
     @Nullable
-    Long getLastEventTimeStamp() {
-        long time = preferences.getLong(RUDDER_LAST_EVENT_TIMESTAMP_KEY, -1);
+    Long getLastActiveTimestamp() {
+        long time = preferences.getLong(RUDDER_LAST_ACTIVE_TIMESTAMP_KEY, -1);
         return (time == -1) ? null : new Long(time);
     }
 
-    void clearLastEventTimeStamp() {
-        preferences.edit().remove(RUDDER_LAST_EVENT_TIMESTAMP_KEY).apply();
+    void clearLastActiveTimestamp() {
+        preferences.edit().remove(RUDDER_LAST_ACTIVE_TIMESTAMP_KEY).apply();
     }
 
     void saveSessionId(Long sessionId) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
@@ -10,14 +10,14 @@ class RudderUserSession {
     private final RudderConfig config;
     private Long sessionId;
     private boolean sessionStart;
-    private Long lastEventTimeStamp;
+    private Long lastActiveTimestamp;
     private RudderPreferenceManager preferenceManager;
 
     RudderUserSession(RudderPreferenceManager _preferenceManager, RudderConfig _config) {
         this.config = _config;
         this.preferenceManager = _preferenceManager;
         this.sessionId = _preferenceManager.getSessionId();
-        this.lastEventTimeStamp = _preferenceManager.getLastEventTimeStamp();
+        this.lastActiveTimestamp = _preferenceManager.getLastEventTimeStamp();
     }
 
     public void startSession() {
@@ -35,13 +35,13 @@ class RudderUserSession {
 
 
     public void startSessionIfNeeded() {
-        if (this.lastEventTimeStamp == null) {
+        if (this.lastActiveTimestamp == null) {
             this.startSession();
             return;
         }
         final long timeDifference;
         synchronized (this) {
-            timeDifference = Math.abs((Utils.getCurrentTimeInMilliSeconds() - this.lastEventTimeStamp));
+            timeDifference = Math.abs((Utils.getCurrentTimeInMilliSeconds() - this.lastActiveTimestamp));
         }
         if (timeDifference > this.config.getSessionTimeout()) {
             refreshSession();
@@ -53,9 +53,9 @@ class RudderUserSession {
         this.startSession();
     }
 
-    public synchronized void updateLastEventTimeStamp() {
-        this.lastEventTimeStamp = Utils.getCurrentTimeInMilliSeconds();
-        this.preferenceManager.saveLastEventTimeStamp(this.lastEventTimeStamp);
+    public synchronized void updateLastActiveTimestamp() {
+        this.lastActiveTimestamp = Utils.getCurrentTimeInMilliSeconds();
+        this.preferenceManager.saveLastEventTimeStamp(this.lastActiveTimestamp);
     }
 
     @Nullable
@@ -75,7 +75,7 @@ class RudderUserSession {
         this.sessionId = null;
         this.preferenceManager.clearSessionId();
         this.sessionStart = true;
-        this.lastEventTimeStamp = null;
+        this.lastActiveTimestamp = null;
         this.preferenceManager.clearLastEventTimeStamp();
     }
 }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
@@ -17,7 +17,7 @@ class RudderUserSession {
         this.config = _config;
         this.preferenceManager = _preferenceManager;
         this.sessionId = _preferenceManager.getSessionId();
-        this.lastActiveTimestamp = _preferenceManager.getLastEventTimeStamp();
+        this.lastActiveTimestamp = _preferenceManager.getLastActiveTimestamp();
     }
 
     public void startSession() {
@@ -55,7 +55,7 @@ class RudderUserSession {
 
     public synchronized void updateLastActiveTimestamp() {
         this.lastActiveTimestamp = Utils.getCurrentTimeInMilliSeconds();
-        this.preferenceManager.saveLastEventTimeStamp(this.lastActiveTimestamp);
+        this.preferenceManager.saveLastActiveTimestamp(this.lastActiveTimestamp);
     }
 
     @Nullable
@@ -76,6 +76,6 @@ class RudderUserSession {
         this.preferenceManager.clearSessionId();
         this.sessionStart = true;
         this.lastActiveTimestamp = null;
-        this.preferenceManager.clearLastEventTimeStamp();
+        this.preferenceManager.clearLastActiveTimestamp();
     }
 }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
@@ -11,7 +11,7 @@ class RudderUserSession {
     private Long sessionId;
     private boolean sessionStart;
     private Long lastActiveTimestamp;
-    private RudderPreferenceManager preferenceManager;
+    private final RudderPreferenceManager preferenceManager;
 
     RudderUserSession(RudderPreferenceManager _preferenceManager, RudderConfig _config) {
         this.config = _config;

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
@@ -4,8 +4,8 @@ import androidx.annotation.Nullable;
 
 public class RudderUserSessionManager {
     private RudderUserSession userSession;
-    private RudderPreferenceManager preferenceManager;
-    private RudderConfig config;
+    private final RudderPreferenceManager preferenceManager;
+    private final RudderConfig config;
 
     public RudderUserSessionManager(RudderPreferenceManager preferenceManager, RudderConfig config) {
         this.preferenceManager = preferenceManager;

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
@@ -44,7 +44,7 @@ public class RudderUserSessionManager {
             message.setSession(userSession);
         }
         if (isAutomaticSessionTrackingEnabled()) {
-            userSession.updateLastEventTimeStamp();
+            userSession.updateLastActiveTimestamp();
         }
     }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSessionManager.java
@@ -79,6 +79,9 @@ public class RudderUserSessionManager {
     public void reset() {
         if (getSessionId() != null) {
             userSession.refreshSession();
+            if (isAutomaticSessionTrackingEnabled()) {
+                userSession.updateLastActiveTimestamp();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

- Refactor variable and method name: `updateLastEventTimeStamp` to `updateLastActiveTimestamp`.
- Fix: Update the last active timestamp value when the RESET call is made. This will prevent the SDK from generating a new sessionId, when the app is relaunched following a force close after a RESET call has been made. (Note: This fix might be temporary and we can decide to change it based on further discussion.)

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
