### PR TITLE
fix: db downgrade issue on v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Version -1.5.3 - 2023-12-2
+
+### Fixed
+- Db down-gradation issues when the SDK is downgraded from DB version > 1 to 1.
+
 ## Version - 1.0 - 2020-02-10
 ### Added
 - Automatic App Life cycle events tracking is added. `Application Installed`, `Application Updated`, `Application Opened`, `Application Backgrounded`. It is tracked by default and can be turned off using `RudderConfig`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ allprojects {
 
 ```groovy
 
-implementation 'com.rudderstack.android.sdk:core:1.5.2'
+implementation 'com.rudderstack.android.sdk:core:1.5.3'
 ```
 
 ## Initializing ```RudderClient```

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31'
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10'
+        classpath 'com.google.gms:google-services:4.3.10'
     }
 }
 
@@ -21,6 +23,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
-        versionName '1.5.2'
+        versionName '1.5.3'
         consumerProguardFiles 'proguard-consumer-rules.pro'
     }
 
@@ -54,7 +54,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.rudderstack.android.sdk'
-    PUBLISH_VERSION = '1.5.2'
+    PUBLISH_VERSION = '1.5.3'
     PUBLISH_ARTIFACT_ID = 'core'
 }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
@@ -33,5 +33,5 @@ class Constants {
     // whether we should record screen views automatically
     static final boolean RECORD_SCREEN_VIEWS = false;
     // current version of the library
-    static final String RUDDER_LIBRARY_VERSION = "1.5.2";
+    static final String RUDDER_LIBRARY_VERSION = "1.5.3";
 }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -255,6 +255,10 @@ class DBPersistentManager extends SQLiteOpenHelper {
         // basically do nothing
     }
 
+    @Override
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    }
+
     public void deleteAllEvents() {
         try {
             SQLiteDatabase database = getWritableDatabase();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderLibraryInfo.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderLibraryInfo.java
@@ -6,5 +6,5 @@ class RudderLibraryInfo {
     @SerializedName("name")
     private String name = BuildConfig.LIBRARY_PACKAGE_NAME;
     @SerializedName("version")
-    private String version = "1.5.2";
+    private String version = "1.5.3";
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -1,17 +1,6 @@
-buildscript {
-    ext.kotlin_version = '1.4.30'
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70"
-    }
-}
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+//apply plugin: 'kotlin-android-extensions'
 
 
 android {
@@ -29,7 +18,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            useProguard true
+//            useProguard true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -45,17 +34,18 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+//    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation project(':core')
+//    implementation project(':core')
+    implementation 'com.rudderstack.android.sdk:core:1.21.0'
 
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    implementation 'com.google.android.gms:play-services-ads:19.3.0'
+//    implementation 'com.google.android.gms:play-services-ads:19.3.0'
 
     implementation "androidx.work:work-runtime:2.7.1"
     //multidex

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -40,8 +40,10 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0'
 
-//    implementation project(':core')
-    implementation 'com.rudderstack.android.sdk:core:1.21.0'
+//    implementation 'com.rudderstack.android.sdk:core:1.5.1'
+    implementation project(':core')  // 1.5.3
+//    implementation 'com.rudderstack.android.sdk:core:1.21.0'
+
 
     implementation 'com.google.code.gson:gson:2.8.6'
 

--- a/sample-kotlin/src/main/java/com/rudderstack/android/sample/kotlin/FirstActivity.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/sample/kotlin/FirstActivity.kt
@@ -3,15 +3,15 @@ package com.rudderstack.android.sample.kotlin
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.activity_first.*
+//import kotlinx.android.synthetic.main.activity_first.*
 
 class FirstActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_first)
 
-        navigate_to_second.setOnClickListener {
-            startActivity(Intent(this, SecondActivity::class.java))
-        }
+//        navigate_to_second.setOnClickListener {
+//            startActivity(Intent(this, SecondActivity::class.java))
+//        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':sample-cdn', ':sample-kotlin', ':core', ':sample-segment-java', ':sample-kotlin-integration', ':dummy-impl', ':android-tv'
+include ':sample-kotlin', ':core'


### PR DESCRIPTION
## Description 

- This will fix the db downgrade issue in Android by overriding the `onDowngrade` method.
- The base version is 1.5.2 and this fix has been implemented on top of it.
- Now, if someone wants to revert from any version >1.5.3 to this (1.5.3) version, no exception will occur.
- Now, if someone wants to revert from v1.5.3 to v1.5.1, no exception will occur.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
