### PR TITLE
fix: batches failed to be sent to data plane

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -503,10 +503,6 @@ class EventRepository {
     }
 
     private RudderMessage updateMessageWithConsentedDestinations(RudderMessage message) {
-        RudderClient rudderClient = RudderClient.getInstance();
-        if (rudderClient == null)
-            return message;
-
         if (consentFilterHandler == null) {
             return message;
         }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -102,7 +102,7 @@ public class RudderCloudModeManager {
     }
 
     private void deleteEventsWithoutAnonymousId(ArrayList<String> messages, ArrayList<Integer> messageIds) {
-        List<Integer> eventsToDelete = new ArrayList();
+        List<Integer> eventsToDelete = new ArrayList<>();
         for (int i = 0; i < messages.size(); i++) {
             Map<String, Object> message = RudderGson.getInstance().fromJson(messages.get(i), Map.class);
             if (!message.containsKey("anonymousId") || message.get("anonymousId") == null) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -1,6 +1,5 @@
 package com.rudderstack.android.sdk.core;
 
-import static com.rudderstack.android.sdk.core.ReportManager.LABEL_TYPE;
 import static com.rudderstack.android.sdk.core.ReportManager.incrementCloudModeUploadRetryCounter;
 import static com.rudderstack.android.sdk.core.ReportManager.incrementDiscardedCounter;
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.NetworkResponses;
@@ -8,8 +7,8 @@ import static com.rudderstack.android.sdk.core.RudderNetworkManager.RequestMetho
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.Result;
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.addEndPoint;
 
+import com.rudderstack.android.sdk.core.gson.RudderGson;
 import com.rudderstack.android.sdk.core.util.MessageUploadLock;
-import com.rudderstack.android.sdk.core.util.Utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,6 +78,10 @@ public class RudderCloudModeManager {
                             case WRITE_KEY_ERROR:
                                 RudderLogger.logError("CloudModeManager: cloudModeProcessor: Wrong WriteKey. Terminating the Cloud Mode Processor");
                                 return;
+                            case MISSING_ANONYMOUSID_AND_USERID:
+                                RudderLogger.logError("CloudModeManager: cloudModeProcessor: Request Failed as the batch payload contains events without anonymousId and userId, hence deleting those events from DB");
+                                deleteEventsWithoutAnonymousId(messages, messageIds);
+                                break;
                             case ERROR:
                             case NETWORK_UNAVAILABLE:
                                 RudderLogger.logWarn("CloudModeManager: cloudModeProcessor: Retrying in " + Math.abs(sleepCount - config.getSleepTimeOut()) + "s");
@@ -96,6 +99,20 @@ public class RudderCloudModeManager {
                 }
             }
         }.start();
+    }
+
+    private void deleteEventsWithoutAnonymousId(ArrayList<String> messages, ArrayList<Integer> messageIds) {
+        List<Integer> eventsToDelete = new ArrayList();
+        for (int i = 0; i < messages.size(); i++) {
+            RudderMessage message = RudderGson.getInstance().fromJson(messages.get(i), RudderMessage.class);
+            if (message.getAnonymousId() == null) {
+                eventsToDelete.add(messageIds.get(i));
+            }
+        }
+        if (!eventsToDelete.isEmpty()) {
+            dbManager.clearEventsFromDB(eventsToDelete);
+            RudderLogger.logDebug(String.format(Locale.US, "CloudModeManager: deleteEventsWithoutUserIdAndAnonymousId: Deleted %d events from DB", eventsToDelete.size()));
+        }
     }
 
     /*

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -1,7 +1,6 @@
 package com.rudderstack.android.sdk.core;
 
 import static com.rudderstack.android.sdk.core.ReportManager.incrementCloudModeUploadRetryCounter;
-import static com.rudderstack.android.sdk.core.ReportManager.incrementDiscardedCounter;
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.NetworkResponses;
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.RequestMethod;
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.Result;
@@ -14,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class RudderCloudModeManager {
 
@@ -104,8 +104,8 @@ public class RudderCloudModeManager {
     private void deleteEventsWithoutAnonymousId(ArrayList<String> messages, ArrayList<Integer> messageIds) {
         List<Integer> eventsToDelete = new ArrayList();
         for (int i = 0; i < messages.size(); i++) {
-            RudderMessage message = RudderGson.getInstance().fromJson(messages.get(i), RudderMessage.class);
-            if (message.getAnonymousId() == null) {
+            Map<String, Object> message = RudderGson.getInstance().fromJson(messages.get(i), Map.class);
+            if (!message.containsKey("anonymousId") || message.get("anonymousId") == null) {
                 eventsToDelete.add(messageIds.get(i));
             }
         }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderNetworkManager.java
@@ -42,6 +42,7 @@ public class RudderNetworkManager {
         SUCCESS,
         ERROR,
         WRITE_KEY_ERROR,
+        MISSING_ANONYMOUSID_AND_USERID,
         RESOURCE_NOT_FOUND,
         NETWORK_UNAVAILABLE,
         BAD_REQUEST
@@ -150,6 +151,8 @@ public class RudderNetworkManager {
                         httpConnection.getURL(), responseCode, errorPayload));
                 if (errorPayload != null && errorPayload.toLowerCase().contains("invalid write key"))
                     networkResponse = NetworkResponses.WRITE_KEY_ERROR;
+                else if (errorPayload != null && errorPayload.toLowerCase().contains("request neither has anonymousid nor userid"))
+                    networkResponse = NetworkResponses.MISSING_ANONYMOUSID_AND_USERID;
                 else if (responseCode == 404)
                     networkResponse = NetworkResponses.RESOURCE_NOT_FOUND;
                 else if (responseCode == 400)


### PR DESCRIPTION
## fix: batches failed to be sent from the mobile SDKs

Due to a race condition occurring when events are triggered from another thread while the SDK is getting initialized, the generated event payloads are missing `anonymousId`, `context`, & `userId`. 

These events were causing the requests made to the `/batch` endpoint of the data plane to fail with an error message: `Request neither has anonymousId nor userId`.

Hence, to fix this issue, we made the `RudderClient` class thread-safe and added the capability to delete invalid events from the DB when we receive `Request neither has anonymousId nor userId` from the data plane.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
