### PR TITLE
fix: fixed serialization of strings twice

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -109,6 +109,7 @@ public class Utils {
      * Convert an object to a map
      * <p> Serialize the object to a json string and then convert it to a map </p>
      * <p> If the object is a string, it is directly converted to a map </p>
+     * <p> If the object results in an invalid json string after serialization, an empty map is returned </p>
      *
      * @param obj the object to convert
      * @return the map representation of the object
@@ -129,6 +130,7 @@ public class Utils {
      * Convert an object to a list
      * <p> Serialize the object to a json string and then convert it to a list </p>
      * <p> If the object is a string, it is directly converted to a list </p>
+     * <p> If the object results in an invalid json string after serialization, an empty list is returned </p>
      *
      * @param obj the object to convert
      * @return the list representation of the object

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -94,13 +94,19 @@ public class Utils {
         return null;
     }
 
-    public static Map<String, Object> convertToMap(Object obj) {
+    @Nullable
+    private static String serializeObject(Object obj) {
         String json;
         if (obj instanceof String) {
             json = (String) obj;
         } else {
             json = RudderGson.serialize(obj);
         }
+        return json;
+    }
+
+    public static Map<String, Object> convertToMap(Object obj) {
+        String json = serializeObject(obj);
         if (json == null) {
             return new HashMap<>();
         }
@@ -111,14 +117,8 @@ public class Utils {
         return map == null ? new HashMap<>() : map;
     }
 
-
     public static List<Map<String, Object>> convertToList(Object obj) {
-        String json;
-        if (obj instanceof String) {
-            json = (String) obj;
-        } else {
-            json = RudderGson.serialize(obj);
-        }
+        String json = serializeObject(obj);
 
         if (json == null) {
             return new ArrayList<>();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -105,6 +105,14 @@ public class Utils {
         return json;
     }
 
+    /**
+     * Convert an object to a map
+     * <p> Serialize the object to a json string and then convert it to a map </p>
+     * <p> If the object is a string, it is directly converted to a map </p>
+     *
+     * @param obj the object to convert
+     * @return the map representation of the object
+     */
     public static Map<String, Object> convertToMap(Object obj) {
         String json = serializeObject(obj);
         if (json == null) {
@@ -117,6 +125,14 @@ public class Utils {
         return map == null ? new HashMap<>() : map;
     }
 
+    /**
+     * Convert an object to a list
+     * <p> Serialize the object to a json string and then convert it to a list </p>
+     * <p> If the object is a string, it is directly converted to a list </p>
+     *
+     * @param obj the object to convert
+     * @return the list representation of the object
+     */
     public static List<Map<String, Object>> convertToList(Object obj) {
         String json = serializeObject(obj);
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -95,7 +95,12 @@ public class Utils {
     }
 
     public static Map<String, Object> convertToMap(Object obj) {
-        String json = RudderGson.serialize(obj);
+        String json;
+        if (obj instanceof String) {
+            json = (String) obj;
+        } else {
+            json = RudderGson.serialize(obj);
+        }
         if (json == null) {
             return new HashMap<>();
         }
@@ -108,7 +113,13 @@ public class Utils {
 
 
     public static List<Map<String, Object>> convertToList(Object obj) {
-        String json = RudderGson.serialize(obj);
+        String json;
+        if (obj instanceof String) {
+            json = (String) obj;
+        } else {
+            json = RudderGson.serialize(obj);
+        }
+
         if (json == null) {
             return new ArrayList<>();
         }

--- a/core/src/test/java/com/rudderstack/android/sdk/core/UtilsTest.java
+++ b/core/src/test/java/com/rudderstack/android/sdk/core/UtilsTest.java
@@ -1,0 +1,26 @@
+package com.rudderstack.android.sdk.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.rudderstack.android.sdk.core.util.Utils;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class UtilsTest {
+    @Test
+    public void testStringConversiontToMap() {
+        String rudderTraits = "{\"dirty\":{\"general\":45.0,\"minValue\":4.9E-324,\"maxValue\":1.7976931348623157E308,\"double\":45.0,\"positiveInfinity\":\"Infinity\",\"nan\":\"NaN\",\"float\":45.0,\"list\":[\"Infinity\",\"-Infinity\",1.7976931348623157E308,4.9E-324,\"NaN\",45.0,45.0],\"map\":{\"general\":45.0,\"minValue\":4.9E-324,\"maxValue\":1.7976931348623157E308,\"double\":45.0,\"positiveInfinity\":\"Infinity\",\"nan\":\"NaN\",\"negativeInfinity\":\"-Infinity\"},\"long\":45.0,\"int\":45.0,\"negativeInfinity\":\"-Infinity\"},\"anonymousId\":\"c5ee2cf1-97a3-4744-80fc-faabce7a7e51\",\"name\":\"Mr. User1\",\"id\":\"new user 2\",\"userId\":\"new user 2\",\"email\":\"user1@gmail.com\"}";
+        Map<String,Object> map = Utils.convertToMap(rudderTraits);
+        assertThat("Map should not be empty", map.size() > 0);
+    }
+
+    @Test
+    public void testStringConversionToArray() {
+        String externalIds = "[{\"id\":\"idValue\",\"type\":\"idTYpe\"}]";
+        List<Map<String, Object>> list = Utils.convertToList(externalIds);
+        assertThat("List should not be empty", list.size() > 0);
+    }
+}


### PR DESCRIPTION
# fixed serialization of strings twice

* When a String is serialized again using Gson, it is converted into a format which cannot be de-serialized back by Gson, fixed this by not serializing a String in the places where it is needed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
