### PR TITLE
feat: assert size of message and batch

### DIFF
--- a/android/src/main/java/com/rudderstack/android/storage/AndroidStorageImpl.kt
+++ b/android/src/main/java/com/rudderstack/android/storage/AndroidStorageImpl.kt
@@ -347,6 +347,12 @@ class AndroidStorageImpl(
         messageDao?.delete(null, null)
     }
 
+    override fun deleteMessagesSync(messages: List<Message>) {
+        with(messageDao ?: return) {
+            messages.entities.filterNotNull().deleteSync()
+        }
+    }
+
     override val startupQueue: List<Message>
         get() = startupQ
     override val isOptedOut: Boolean

--- a/android/src/test/java/com/rudderstack/android/android/AndroidStorageTest.kt
+++ b/android/src/test/java/com/rudderstack/android/android/AndroidStorageTest.kt
@@ -181,7 +181,20 @@ abstract class AndroidStorageTest {
         storage.clearSessionId()
         MatcherAssert.assertThat(storage.sessionId, Matchers.nullValue())
     }
+    @Test
+    fun `test delete sync`(){
+        val storage = analytics.storage as AndroidStorage
+        storage.clearStorage()
+        val events = (1..20).map {
+            TrackMessage.create("event:$it", RudderUtils.timeStamp)
+        }
+        storage.saveMessage(*events.toTypedArray())
+        while (storage.getDataSync().size != 20) {
+        }
+        storage.deleteMessagesSync(events.take(10))
+        MatcherAssert.assertThat(storage.getDataSync(), Matchers.iterableWithSize(10))
 
+    }
 }
 
 @RunWith(AndroidJUnit4::class)

--- a/core/src/main/java/com/rudderstack/core/BasicStorageImpl.kt
+++ b/core/src/main/java/com/rudderstack/core/BasicStorageImpl.kt
@@ -142,13 +142,8 @@ class BasicStorageImpl @JvmOverloads constructor(
     }
 
     override fun deleteMessages(messages: List<Message>) {
-        val messageIdsToRemove = messages.map { it.messageId }
-        synchronized(this) {
-            queue.removeAll {
-                it.messageId in messageIdsToRemove
-            }
-        }
-        onDataChange()
+        //basic storage does not support async delete
+        deleteMessagesSync(messages)
     }
 
     override fun addMessageDataListener(listener: Storage.DataListener) {
@@ -236,6 +231,16 @@ class BasicStorageImpl @JvmOverloads constructor(
             _serverConfig = null
             serverConfigFile.delete()
         }
+    }
+
+    override fun deleteMessagesSync(messages: List<Message>) {
+        val messageIdsToRemove = messages.map { it.messageId }
+        synchronized(this) {
+            queue.removeAll {
+                it.messageId in messageIdsToRemove
+            }
+        }
+        onDataChange()
     }
 
 

--- a/core/src/main/java/com/rudderstack/core/RudderUtils.kt
+++ b/core/src/main/java/com/rudderstack/core/RudderUtils.kt
@@ -54,4 +54,12 @@ object RudderUtils {
         }
     }
 
+    internal fun getUTF8Length(message: String): Int {
+        return try {
+            message.toByteArray(Charsets.UTF_8).size
+        } catch (ex: UnsupportedEncodingException) {
+            -1
+        }
+    }
+
 }

--- a/core/src/main/java/com/rudderstack/core/RudderUtils.kt
+++ b/core/src/main/java/com/rudderstack/core/RudderUtils.kt
@@ -54,9 +54,9 @@ object RudderUtils {
         }
     }
 
-    internal fun getUTF8Length(message: String): Int {
+    internal fun String.getUTF8Length(): Int {
         return try {
-            message.toByteArray(Charsets.UTF_8).size
+            this.toByteArray(Charsets.UTF_8).size
         } catch (ex: UnsupportedEncodingException) {
             -1
         }

--- a/core/src/main/java/com/rudderstack/core/Storage.kt
+++ b/core/src/main/java/com/rudderstack/core/Storage.kt
@@ -65,7 +65,7 @@ interface Storage : InfrastructurePlugin{
     fun setBackpressureStrategy(strategy: BackPressureStrategy = BackPressureStrategy.Drop)
 
     /**
-     * Delete Messages, preferably when no longer required
+     * Delete Messages, preferably when no longer required in an async manner
      *
      * @param messages [Message] objects ready to be removed from storage
      */
@@ -151,6 +151,12 @@ interface Storage : InfrastructurePlugin{
      *
      */
     fun clearStorage()
+    /**
+     * Delete Messages, preferably when no longer required in an sync manner on the calling thread
+     *
+     * @param messages [Message] objects ready to be removed from storage
+     */
+    fun deleteMessagesSync(messages: List<Message>)
 
     /**
      * @see saveStartupMessageInQueue

--- a/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
@@ -391,7 +391,7 @@ internal class AnalyticsDelegate(
                     }
                     if (response.success) {
                         latestData.successCallback()
-                        storage.deleteMessages(latestData) //TODO  add deleteSync function in dao
+                        storage.deleteMessagesSync(latestData)
                         latestData = getMessagesTrimmedToMaxSize()
 
                     } else {

--- a/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
@@ -27,7 +27,7 @@ import com.rudderstack.core.LifecycleController
 import com.rudderstack.core.Logger
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderOptions
-import com.rudderstack.core.RudderUtils
+import com.rudderstack.core.RudderUtils.getUTF8Length
 import com.rudderstack.core.RudderUtils.MAX_BATCH_SIZE
 import com.rudderstack.core.Storage
 import com.rudderstack.core.flushpolicy.CountBasedFlushPolicy
@@ -418,7 +418,7 @@ internal class AnalyticsDelegate(
 
         for (message in data) {
             val messageJSON: String? = config.jsonAdapter.writeToJson(message, object : RudderTypeAdapter<Message>() {})
-            val messageSize = RudderUtils.getUTF8Length(messageJSON.toString())
+            val messageSize = messageJSON.toString().getUTF8Length()
 
             totalMessageSize += messageSize
 

--- a/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
@@ -29,7 +29,6 @@ import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderOptions
 import com.rudderstack.core.Storage
 import com.rudderstack.core.flushpolicy.CountBasedFlushPolicy
-import com.rudderstack.core.flushpolicy.FlushPolicy
 import com.rudderstack.core.flushpolicy.IntervalBasedFlushPolicy
 import com.rudderstack.core.flushpolicy.addFlushPolicies
 import com.rudderstack.core.flushpolicy.applyFlushPoliciesClosure
@@ -39,6 +38,7 @@ import com.rudderstack.core.holder.retrieveState
 import com.rudderstack.core.internal.plugins.DestinationConfigurationPlugin
 import com.rudderstack.core.internal.plugins.EventFilteringPlugin
 import com.rudderstack.core.internal.plugins.GDPRPlugin
+import com.rudderstack.core.internal.plugins.EventSizeFilterPlugin
 import com.rudderstack.core.internal.plugins.RudderOptionPlugin
 import com.rudderstack.core.internal.plugins.StoragePlugin
 import com.rudderstack.core.internal.plugins.WakeupActionPlugin
@@ -147,6 +147,7 @@ internal class AnalyticsDelegate(
 
     //plugins
     private val gdprPlugin = GDPRPlugin()
+    private val eventSizeFilterPlugin = EventSizeFilterPlugin()
     private val storagePlugin = StoragePlugin()
     private val wakeupActionPlugin = WakeupActionPlugin()
     private val eventFilteringPlugin = EventFilteringPlugin()
@@ -556,6 +557,7 @@ internal class AnalyticsDelegate(
     private fun initializeMessagePlugins() {
         // check if opted out
         _internalPreMessagePlugins = _internalPreMessagePlugins + gdprPlugin
+        _internalPostCustomPlugins = _internalPostCustomPlugins + eventSizeFilterPlugin
         // rudder option plugin followed by extract state plugin should be added by lifecycle
         // add defaults to message
 //        _internalPrePlugins = _internalPrePlugins + anonymousIdPlugin

--- a/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
@@ -428,8 +428,6 @@ internal class AnalyticsDelegate(
             }
             index++
         }
-        // 512000
-        println("$totalMessageSize $MAX_BATCH_SIZE")
 
         return data.subList(0, index)
     }

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/EventSizeFilterPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/EventSizeFilterPlugin.kt
@@ -23,7 +23,7 @@ class EventSizeFilterPlugin : Plugin {
             val messageJSON = chain.message().let {
                 config.jsonAdapter.writeToJson(it, object : RudderTypeAdapter<Message>() {})
             }
-            val messageSize = getUTF8Length(messageJSON.toString())
+            val messageSize = messageJSON.toString().getUTF8Length()
             if (messageSize > MAX_EVENT_SIZE) {
                 config.logger.error(log = "Event size exceeds the maximum size of $MAX_EVENT_SIZE bytes. Dropping the event.")
                 return chain.message()

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/EventSizeFilterPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/EventSizeFilterPlugin.kt
@@ -8,6 +8,9 @@ import com.rudderstack.models.Message
 import com.rudderstack.rudderjsonadapter.RudderTypeAdapter
 import java.util.concurrent.atomic.AtomicReference
 
+/**
+ * A plugin to filter out events that exceed the maximum size limit.
+ */
 class EventSizeFilterPlugin : Plugin {
 
     private val currentConfigurationAtomic = AtomicReference<Configuration?>()

--- a/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
+++ b/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
@@ -14,6 +14,7 @@
 
 package com.rudderstack.core
 
+import com.rudderstack.core.RudderUtils.getUTF8Length
 import com.rudderstack.core.holder.retrieveState
 import com.rudderstack.core.internal.states.DestinationConfigState
 import com.rudderstack.gsonrudderadapter.GsonAdapter
@@ -866,7 +867,7 @@ abstract class AnalyticsTest {
             analytics.currentConfiguration?.jsonAdapter?.writeToJson(it, object : RudderTypeAdapter<Message>() {})
         } ?: return 0
 
-        val individualMessageSize = RudderUtils.getUTF8Length(messageJSON)
+        val individualMessageSize = messageJSON.getUTF8Length()
         if (individualMessageSize == 0) {
             return 0
         }

--- a/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
+++ b/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
@@ -841,11 +841,12 @@ class JacksonAnalyticsTest : AnalyticsTest() {
 
 }
 
-class MoshiAnalyticsTest : AnalyticsTest() {
-    override val jsonAdapter: JsonAdapter
-        get() = MoshiAdapter()
-
-}
+// Currently, we are not supporting Moshi adapter.
+//class MoshiAnalyticsTest : AnalyticsTest() {
+//    override val jsonAdapter: JsonAdapter
+//        get() = MoshiAdapter()
+//
+//}
 
 @RunWith(Suite::class)
 @Suite.SuiteClasses(/*MoshiAnalyticsTest::class, JacksonAnalyticsTest::class, */GsonAnalyticsTest::class

--- a/core/src/test/java/com/rudderstack/core/internal/plugins/EventSizeFilterPluginTest.kt
+++ b/core/src/test/java/com/rudderstack/core/internal/plugins/EventSizeFilterPluginTest.kt
@@ -62,7 +62,7 @@ class EventSizeFilterPluginTest {
             customContextMap = null
         ).also { message ->
             val messageJSON = currentConfiguration.jsonAdapter.writeToJson(message)
-            val messageSize = getUTF8Length(messageJSON.toString())
+            val messageSize = messageJSON.toString().getUTF8Length()
             assert(messageSize < MAX_EVENT_SIZE)
         }
     }
@@ -81,7 +81,7 @@ class EventSizeFilterPluginTest {
             properties = properties
         ).also { message ->
             val messageJSON = currentConfiguration.jsonAdapter.writeToJson(message)
-            val messageSize = getUTF8Length(messageJSON.toString())
+            val messageSize = messageJSON.toString().getUTF8Length()
             assert(messageSize > MAX_EVENT_SIZE)
         }
     }

--- a/core/src/test/java/com/rudderstack/core/internal/plugins/EventSizeFilterPluginTest.kt
+++ b/core/src/test/java/com/rudderstack/core/internal/plugins/EventSizeFilterPluginTest.kt
@@ -1,0 +1,88 @@
+package com.rudderstack.core.internal.plugins
+
+import com.rudderstack.core.Configuration
+import com.rudderstack.core.Plugin
+import com.rudderstack.core.RudderUtils
+import com.rudderstack.core.RudderUtils.MAX_EVENT_SIZE
+import com.rudderstack.core.RudderUtils.getUTF8Length
+import com.rudderstack.core.internal.CentralPluginChain
+import com.rudderstack.gsonrudderadapter.GsonAdapter
+import com.rudderstack.models.Message
+import com.rudderstack.models.TrackMessage
+import org.junit.Test
+
+class EventSizeFilterPluginTest {
+
+    private val eventSizeFilterPlugin = EventSizeFilterPlugin()
+    private val currentConfiguration = Configuration(jsonAdapter = GsonAdapter(), isOptOut = false)
+
+    @Test
+    fun `given event size does not exceed the maximum size, then the next plugin in the chain should be called`() {
+        var isCalled = false
+        val testPlugin = Plugin {
+            isCalled = true
+            it.proceed(it.message())
+        }
+        val message = getMessageUnderMaxSize()
+        val eventSizeFilterTestChain = CentralPluginChain(message, listOf(eventSizeFilterPlugin, testPlugin))
+        eventSizeFilterPlugin.updateConfiguration(currentConfiguration)
+
+        val returnedMsg = eventSizeFilterTestChain.proceed(message)
+        assert(returnedMsg == message)
+        assert(isCalled)
+    }
+
+    @Test
+    fun `given event size exceeds the maximum size, then the next plugin in the chain should not be called`() {
+        var isCalled = false
+        val testPlugin = Plugin {
+            isCalled = true
+            it.proceed(it.message())
+        }
+        val message = getMessageOverMaxSize()
+        val eventSizeFilterTestChain = CentralPluginChain(message, listOf(eventSizeFilterPlugin, testPlugin))
+        eventSizeFilterPlugin.updateConfiguration(currentConfiguration)
+
+        val returnedMsg = eventSizeFilterTestChain.proceed(message)
+        assert(returnedMsg == message)
+        assert(!isCalled)
+    }
+
+    private fun getMessageUnderMaxSize(): Message {
+        return TrackMessage.create(
+            "ev-1", RudderUtils.timeStamp,
+            traits = mapOf(
+                "age" to 31,
+                "office" to "Rudderstack"
+            ),
+            externalIds = listOf(
+                mapOf("some_id" to "s_id"),
+                mapOf("amp_id" to "amp_id"),
+            ),
+            customContextMap = null
+        ).also { message ->
+            val messageJSON = currentConfiguration.jsonAdapter.writeToJson(message)
+            val messageSize = getUTF8Length(messageJSON.toString())
+            assert(messageSize < MAX_EVENT_SIZE)
+        }
+    }
+
+    private fun getMessageOverMaxSize(): Message {
+        fun generateDataOfSize(msgSize: Int): String {
+            return CharArray(msgSize).apply { fill('a') }.joinToString("")
+        }
+
+        val properties = mutableMapOf<String, Any>()
+        properties["property"] = generateDataOfSize(1024 * 33)
+
+        return TrackMessage.create(
+            "ev-1",
+            RudderUtils.timeStamp,
+            properties = properties
+        ).also { message ->
+            val messageJSON = currentConfiguration.jsonAdapter.writeToJson(message)
+            val messageSize = getUTF8Length(messageJSON.toString())
+            assert(messageSize > MAX_EVENT_SIZE)
+        }
+    }
+}

--- a/libs/test-common/src/main/java/com/vagabond/testcommon/VerificationStorage.kt
+++ b/libs/test-common/src/main/java/com/vagabond/testcommon/VerificationStorage.kt
@@ -41,7 +41,8 @@ class VerificationStorage : Storage {
     }
 
     override fun deleteMessages(messages: List<Message>) {
-        storageQ -= messages.toSet()
+        // does not support async delete
+        deleteMessagesSync(messages)
     }
 
     override fun addMessageDataListener(listener: Storage.DataListener) {
@@ -89,6 +90,10 @@ class VerificationStorage : Storage {
 
     override fun clearStorage() {
         storageQ.clear()
+    }
+
+    override fun deleteMessagesSync(messages: List<Message>) {
+        storageQ -= messages.toSet()
     }
 
     override val startupQueue: List<Message>


### PR DESCRIPTION
## Description

- Added the feature to ensure individual message size is not greater than 32KB.
- Added the feature to ensure batch size is not greater than 500KB.
- Added new API `deleteMessagesSync` to delete the message from the local DB/storage in a sync way.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
