### PR TITLE
feat: added persistence support for advertisingId and api to clear advertisingId

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
@@ -628,11 +628,9 @@ public class RudderClient {
     }
 
     /**
-     * Set the AdvertisingId yourself. If set, SDK will not capture idfa automatically
+     * Set the AdvertisingId yourself. If set, SDK will not capture advertisingId automatically
      *
-     * <b>Call this method before initializing the RudderClient</b>
-     *
-     * @param advertisingId IDFA for the device
+     * @param advertisingId advertisingId for the device
      */
     public static void putAdvertisingId(@NonNull String advertisingId) {
         if (RudderClient.getInstance() == null) {
@@ -644,6 +642,14 @@ public class RudderClient {
             return;
         }
         RudderElementCache.cachedContext.updateWithAdvertisingId(advertisingId);
+    }
+
+    /**
+     *  Clears the AdvertisingId set manually.
+     */
+
+    public void clearAdvertisingId() {
+         RudderElementCache.cachedContext.clearAdvertisingId();
     }
 
     /**

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderContext.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderContext.java
@@ -106,7 +106,7 @@ public class RudderContext {
 
         this.screenInfo = new RudderScreenInfo(application);
         this.userAgent = System.getProperty("http.agent");
-        this.deviceInfo = new RudderDeviceInfo(advertisingId, deviceToken, collectDeviceId);
+        this.deviceInfo = new RudderDeviceInfo(advertisingId, deviceToken, collectDeviceId, preferenceManger);
         this.networkInfo = new RudderNetwork(application);
         this.osInfo = new RudderOSInfo();
         this.libraryInfo = new RudderLibraryInfo();
@@ -199,6 +199,10 @@ public class RudderContext {
         }
     }
 
+    void clearAdvertisingId() {
+        this.deviceInfo.clearAdvertisingId();
+    }
+
     void updateDeviceWithAdId() {
         if (isOnClassPath("com.google.android.gms.ads.identifier.AdvertisingIdClient")) {
             // This needs to be done each time since the settings may have been updated.
@@ -248,7 +252,7 @@ public class RudderContext {
         if (TextUtils.isEmpty(this.deviceInfo.getAdvertisingId())) {
             // set the values if and only if the values are not set
             // if value exists, it must have been set by the developer. don't overwrite
-            this.deviceInfo.setAdvertisingId((String) advertisingInfo.getClass().getMethod("getId").invoke(advertisingInfo));
+            this.deviceInfo.setAutoCollectedAdvertisingId((String) advertisingInfo.getClass().getMethod("getId").invoke(advertisingInfo));
             this.deviceInfo.setAdTrackingEnabled(true);
         }
 
@@ -273,7 +277,7 @@ public class RudderContext {
         if (TextUtils.isEmpty(this.deviceInfo.getAdvertisingId())) {
             // set the values if and only if the values are not set
             // if value exists, it must have been set by the developer. don't overwrite
-            this.deviceInfo.setAdvertisingId(Settings.Secure.getString(contentResolver, "advertising_id"));
+            this.deviceInfo.setAutoCollectedAdvertisingId(Settings.Secure.getString(contentResolver, "advertising_id"));
             this.deviceInfo.setAdTrackingEnabled(true);
         }
 

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceInfo.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceInfo.java
@@ -32,14 +32,22 @@ class RudderDeviceInfo {
     @SerializedName("advertisingId")
     private String advertisingId;
 
-    RudderDeviceInfo(String advertisingId, String token, boolean collectDeviceId) {
+    RudderDeviceInfo(String advertisingId, String token, boolean collectDeviceId, RudderPreferenceManager preferenceManager) {
+
         if (collectDeviceId) {
             this.deviceId = Utils.getDeviceId(RudderClient.getApplication());
         }
+
+        // update the advertisingId value in persistence, if user specifies one again
+        // if the user didn't pass any advertisingId, then try reading it from preferences
         if (advertisingId != null && !advertisingId.isEmpty()) {
+            preferenceManager.saveAdvertisingId(advertisingId);
             this.advertisingId = advertisingId;
-            this.adTrackingEnabled = true;
+        } else {
+            this.advertisingId = preferenceManager.getAdvertisingId();
         }
+        this.adTrackingEnabled = (this.advertisingId != null);
+
         if (token != null && !token.isEmpty()) {
             this.token = token;
         }
@@ -60,6 +68,15 @@ class RudderDeviceInfo {
 
     void setAdvertisingId(String advertisingId) {
         this.advertisingId = advertisingId;
+        this.adTrackingEnabled = (this.advertisingId != null);
+        if (RudderClient.getApplication() != null) {
+            RudderPreferenceManager preferenceManager = RudderPreferenceManager.getInstance(RudderClient.getApplication());
+            preferenceManager.saveAdvertisingId(advertisingId);
+        }
+    }
+
+    void setAutoCollectedAdvertisingId(String advertisingId) {
+        this.advertisingId = advertisingId;
     }
 
     String getAdvertisingId() {
@@ -68,5 +85,14 @@ class RudderDeviceInfo {
 
     boolean isAdTrackingEnabled() {
         return this.adTrackingEnabled;
+    }
+
+    void clearAdvertisingId() {
+        this.advertisingId = null;
+        this.adTrackingEnabled = (this.advertisingId != null);
+        if (RudderClient.getApplication() != null) {
+            RudderPreferenceManager preferenceManager = RudderPreferenceManager.getInstance(RudderClient.getApplication());
+            preferenceManager.clearAdvertisingId();
+        }
     }
 }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceInfo.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceInfo.java
@@ -32,8 +32,11 @@ class RudderDeviceInfo {
     @SerializedName("advertisingId")
     private String advertisingId;
 
+    private transient RudderPreferenceManager preferenceManager;
+
     RudderDeviceInfo(String advertisingId, String token, boolean collectDeviceId, RudderPreferenceManager preferenceManager) {
 
+        this.preferenceManager = preferenceManager;
         if (collectDeviceId) {
             this.deviceId = Utils.getDeviceId(RudderClient.getApplication());
         }
@@ -68,11 +71,8 @@ class RudderDeviceInfo {
 
     void setAdvertisingId(String advertisingId) {
         this.advertisingId = advertisingId;
-        this.adTrackingEnabled = (this.advertisingId != null);
-        if (RudderClient.getApplication() != null) {
-            RudderPreferenceManager preferenceManager = RudderPreferenceManager.getInstance(RudderClient.getApplication());
-            preferenceManager.saveAdvertisingId(advertisingId);
-        }
+        this.adTrackingEnabled = true;
+        preferenceManager.saveAdvertisingId(advertisingId);
     }
 
     void setAutoCollectedAdvertisingId(String advertisingId) {
@@ -89,10 +89,7 @@ class RudderDeviceInfo {
 
     void clearAdvertisingId() {
         this.advertisingId = null;
-        this.adTrackingEnabled = (this.advertisingId != null);
-        if (RudderClient.getApplication() != null) {
-            RudderPreferenceManager preferenceManager = RudderPreferenceManager.getInstance(RudderClient.getApplication());
-            preferenceManager.clearAdvertisingId();
-        }
+        this.adTrackingEnabled = false;
+        preferenceManager.clearAdvertisingId();
     }
 }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderElementCache.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderElementCache.java
@@ -22,7 +22,8 @@ class RudderElementCache {
         if (cachedContext == null) {
             RudderLogger.logDebug("RudderElementCache: initiating RudderContext");
             cachedContext = new RudderContext(application, anonymousId, advertisingId, deviceToken, isCollectDeviceId);
-            if (isAutoCollectAdvertId) {
+            // we will perform the auto collection of advertisingId only when the user didn't pass any advertisingId by calling the putAdvertisementId()
+            if (cachedContext.getAdvertisingId() == null && isAutoCollectAdvertId) {
                 cachedContext.updateDeviceWithAdId();
             }
         }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderPreferenceManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderPreferenceManager.java
@@ -29,6 +29,8 @@ class RudderPreferenceManager {
     private static final String RUDDER_PERIODIC_WORK_REQUEST_ID_KEY = "rl_periodic_work_request_key";
     private static final String RUDDER_LAST_ACTIVE_TIMESTAMP_KEY = "rl_last_event_timestamp_key";
     private static final String RUDDER_SESSION_ID_KEY = "rl_session_id_key";
+
+    private static final String RUDDER_ADVERTISING_ID_KEY = "rl_advertising_id_key";
     private static final String RUDDER_AUTO_SESSION_TRACKING_STATUS_KEY = "rl_auto_session_tracking_status_key";
     private static final String RUDDER_DMT_HEADER_KEY = "rl_dmt_header_key";
 
@@ -177,6 +179,19 @@ class RudderPreferenceManager {
 
     void clearSessionId() {
         preferences.edit().remove(RUDDER_SESSION_ID_KEY).apply();
+    }
+
+    void saveAdvertisingId(String advertisingId) {
+        preferences.edit().putString(RUDDER_ADVERTISING_ID_KEY, advertisingId).apply();
+    }
+
+    @Nullable
+    String getAdvertisingId() {
+        return preferences.getString(RUDDER_ADVERTISING_ID_KEY, null);
+    }
+
+    void clearAdvertisingId() {
+        preferences.edit().remove(RUDDER_ADVERTISING_ID_KEY).apply();
     }
 
     @Nullable

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -90,6 +90,9 @@ dependencies {
     //work-manager
     implementation 'androidx.work:work-runtime:2.8.1'
 
+    // required for auto collection of advertisingId
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'


### PR DESCRIPTION
### feat: added persistence support for advertisingId and added a new api to clear advertisingId

* Added support for persisting `advertisingId`, so the advertisingId would be attached to all the events made on subsequent app launches.
* Added `clearAdvertisingId()` API on RudderClient to clear the persisted advertisingId. This is an instance method and can be called only after SDK initialization. 
* If the `putAdvertisingId()` API is called when the `auto collection of advertisingId` is enabled, the advertisingId passed by the API is considered, and the auto collection of advertisingId is disabled.
* Auto collection of advertising ID is enabled back only when the manually set advertising Id is cleared by calling the `clearAdvertisementId()` API.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
