### PR TITLE
feat: add support for global customContext option

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -379,6 +379,10 @@ class EventRepository {
             message.setIntegrations(prepareIntegrations());
         }
 
+        mergeGlobalWithLocalCustomContexts(message);
+    }
+
+    private void mergeGlobalWithLocalCustomContexts(RudderMessage message) {
         // Merge local customContext (message.getContext().customContextMap) with global customContext (defaultOption.getCustomContexts()) giving preference to local one.
         RudderOption defaultOption = RudderClient.getDefaultOptions();
         if (defaultOption != null) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -419,6 +419,13 @@ class EventRepository {
     }
 
     void reset() {
+        RudderOption defaultOption = RudderClient.getDefaultOptions();
+        if (defaultOption != null) {
+            // Since the reset operation is intended to reset user-level fields, we clear the globalOptions->customContext field.
+            // The globalOptions->integrations field is a workspace-level setting and should not be cleared.
+            defaultOption.getCustomContexts().clear();
+        }
+
         deviceModeManager.reset();
         RudderLogger.logDebug("EventRepository: reset: resetting the SDK");
         userSessionManager.reset();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -378,6 +378,27 @@ class EventRepository {
         if (!message.getIntegrations().containsKey("All")) {
             message.setIntegrations(prepareIntegrations());
         }
+
+        // Merge local customContext (message.getContext().customContextMap) with global customContext (defaultOption.getCustomContexts()) giving preference to local one.
+        RudderOption defaultOption = RudderClient.getDefaultOptions();
+        if (defaultOption != null) {
+            Map<String, Object> mergedCustomContextValues = new HashMap<>();
+            if (message.getContext().customContextMap != null) {
+                mergedCustomContextValues.putAll(message.getContext().customContextMap);
+            }
+
+            if (!defaultOption.getCustomContexts().isEmpty()) {
+                for (Map.Entry<String, Object> entry : defaultOption.getCustomContexts().entrySet()) {
+                    if (!mergedCustomContextValues.containsKey(entry.getKey())) {
+                        mergedCustomContextValues.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+
+            if (!mergedCustomContextValues.isEmpty()) {
+                message.getContext().setCustomContexts(mergedCustomContextValues);
+            }
+        }
     }
 
     void flushSync() {


### PR DESCRIPTION
# Description

- Add support for the global `customContext` option. This option could now be passed as a part of the SDK initialisation.
- This value will only be persisted in memory and not in SharedPreference.
- This value will be cleared when a RESET call is made.
- This value will be merged with the localOption `customContext` object (i.e., `customContext` option passed at the event level). While merging the local one would be given preference.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
