### PR TITLE
feat: add support for multiple sdk initialisation

### DIFF
--- a/android/src/main/java/com/rudderstack/android/AnalyticsRegistry.kt
+++ b/android/src/main/java/com/rudderstack/android/AnalyticsRegistry.kt
@@ -1,0 +1,54 @@
+package com.rudderstack.android
+
+import androidx.annotation.VisibleForTesting
+import com.rudderstack.core.Analytics
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * AnalyticsRegistry is a singleton object responsible for managing and providing instances of the Analytics class.
+ * It maintains a mapping between write keys and Analytics instances using concurrent hash maps.
+ *
+ * The class provides methods for registering new Analytics instances with unique write keys,
+ * as well as retrieving instances based on write keys.
+ *
+ * Usage:
+ * - To register a new Analytics instance, use the [register] method, providing a write key and the Analytics instance.
+ * - To retrieve an Analytics instance, use the [getInstance] method, passing the write key.
+ *
+ * Note: The class is marked as internal, indicating that it is intended for use within the same module and should not be accessed
+ * from outside the module.
+ */
+internal object AnalyticsRegistry {
+
+    private val writeKeyToInstance: ConcurrentHashMap<String, Analytics> = ConcurrentHashMap()
+
+    /**
+     * Registers a new Analytics instance with the provided write key and Analytics instance.
+     * If an instance with the same write key already exists, it will not be overwritten.
+     *
+     * @param writeKey The unique identifier associated with the Analytics instance.
+     * @param analytics The Analytics instance to be registered.
+     */
+    fun register(writeKey: String, analytics: Analytics) {
+        writeKeyToInstance.putIfAbsent(writeKey, analytics)
+    }
+
+    /**
+     * Retrieves an Analytics instance based on the provided write key.
+     *
+     * @param writeKey The write key associated with the desired Analytics instance.
+     * @return The Analytics instance if found, otherwise null.
+     */
+    fun getInstance(writeKey: String): Analytics? {
+        return writeKeyToInstance[writeKey]
+    }
+
+    /**
+     * Clears the mapping of write keys to Analytics instances.
+     * Note: This method is intended for use in testing scenarios only.
+     */
+    @VisibleForTesting
+    fun clear() {
+        writeKeyToInstance.clear()
+    }
+}

--- a/android/src/main/java/com/rudderstack/android/AnalyticsRegistry.kt
+++ b/android/src/main/java/com/rudderstack/android/AnalyticsRegistry.kt
@@ -29,6 +29,7 @@ internal object AnalyticsRegistry {
      * @param writeKey The unique identifier associated with the Analytics instance.
      * @param analytics The Analytics instance to be registered.
      */
+    @JvmStatic
     fun register(writeKey: String, analytics: Analytics) {
         writeKeyToInstance.putIfAbsent(writeKey, analytics)
     }
@@ -39,6 +40,7 @@ internal object AnalyticsRegistry {
      * @param writeKey The write key associated with the desired Analytics instance.
      * @return The Analytics instance if found, otherwise null.
      */
+    @JvmStatic
     fun getInstance(writeKey: String): Analytics? {
         return writeKeyToInstance[writeKey]
     }

--- a/android/src/main/java/com/rudderstack/android/RudderAnalytics.kt
+++ b/android/src/main/java/com/rudderstack/android/RudderAnalytics.kt
@@ -41,7 +41,7 @@ import com.rudderstack.models.MessageContext
 //bt stuff
 //tv,
 //work manager
-fun RudderAnalytics(
+private fun RudderAnalytics(
     writeKey: String,
     configuration: ConfigurationAndroid,
     dataUploadService: DataUploadService? = null,
@@ -64,6 +64,36 @@ fun RudderAnalytics(
         }).apply {
         startup()
     }
+}
+
+@JvmOverloads
+fun createInstance(
+    writeKey: String,
+    configuration: ConfigurationAndroid,
+    dataUploadService: DataUploadService? = null,
+    configDownloadService: ConfigDownloadService? = null,
+    storage: AndroidStorage = AndroidStorageImpl(
+        configuration.application,
+        writeKey = writeKey,
+        useContentProvider = ConfigurationAndroid.Defaults.USE_CONTENT_PROVIDER
+    ),
+    initializationListener: ((success: Boolean, message: String?) -> Unit)? = null
+): Analytics {
+    return AnalyticsRegistry.getInstance(writeKey)
+        ?: RudderAnalytics(
+            writeKey,
+            configuration,
+            dataUploadService,
+            configDownloadService,
+            storage,
+            initializationListener
+        ).also { analyticsInstance ->
+            AnalyticsRegistry.register(writeKey, analyticsInstance)
+        }
+}
+
+fun getInstance(writeKey: String): Analytics? {
+    return AnalyticsRegistry.getInstance(writeKey)
 }
 
 internal val Analytics.contextState: ContextState?
@@ -119,7 +149,6 @@ fun Analytics.setAnonymousId(anonymousId: String) {
 
 /**
  * Setting the [ConfigurationAndroid.userId] explicitly.
-
  *
  * @param userId String to be used as userId
  */
@@ -170,13 +199,16 @@ internal fun Analytics.processNewContext(
     contextState?.update(newContext)
 }
 
-fun Analytics.applyConfigurationAndroid(androidConfigurationScope: ConfigurationAndroid.() ->
-ConfigurationAndroid){
+fun Analytics.applyConfigurationAndroid(
+    androidConfigurationScope: ConfigurationAndroid.() ->
+    ConfigurationAndroid
+) {
     applyConfiguration {
         if (this is ConfigurationAndroid) androidConfigurationScope()
         else this
     }
 }
+
 val Analytics.currentConfigurationAndroid: ConfigurationAndroid?
     get() = (currentConfiguration as? ConfigurationAndroid)
 

--- a/android/src/main/java/com/rudderstack/android/compat/RudderAnalyticsBuilderCompat.java
+++ b/android/src/main/java/com/rudderstack/android/compat/RudderAnalyticsBuilderCompat.java
@@ -62,7 +62,7 @@ public final class RudderAnalyticsBuilderCompat  {
     }
     public Analytics build() {
 
-        return RudderAnalytics.RudderAnalytics(
+        return RudderAnalytics.createInstance(
                 writeKey,
                 configuration,
                 dataUploadService,

--- a/android/src/test/java/com/rudderstack/android/AnalyticsRegistryTest.kt
+++ b/android/src/test/java/com/rudderstack/android/AnalyticsRegistryTest.kt
@@ -1,0 +1,67 @@
+package com.rudderstack.android
+
+import com.rudderstack.core.Analytics
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+
+class AnalyticsRegistryTest {
+
+    private val writeKey = "writeKey"
+    private val analytics = mockk<Analytics>()
+
+    @Before
+    fun setUp() {
+        AnalyticsRegistry.clear()
+    }
+
+    @Test
+    fun `when register is called with a write key and analytics instance, then the instance should be registered`() {
+        AnalyticsRegistry.register(writeKey, analytics)
+
+        val result = AnalyticsRegistry.getInstance(writeKey)
+        assert(result == analytics)
+    }
+
+    @Test
+    fun `when registering multiple analytics instances with different write keys, then all instances should be registered`() {
+        val writeKey2 = "writeKey2"
+        val analytics2 = mockk<Analytics>()
+
+        AnalyticsRegistry.register(writeKey, analytics)
+        AnalyticsRegistry.register(writeKey2, analytics2)
+
+        val result1 = AnalyticsRegistry.getInstance(writeKey)
+        val result2 = AnalyticsRegistry.getInstance(writeKey2)
+
+        assert(result1 == analytics)
+        assert(result2 == analytics2)
+    }
+
+    @Test
+    fun `given analytics instance already registered with the writeKey, when register is called with same write key and a new analytics instance, then the instance should not be registered`() {
+        AnalyticsRegistry.register(writeKey, analytics)
+
+        val newAnalytics = mockk<Analytics>()
+        AnalyticsRegistry.register(writeKey, newAnalytics)
+
+        val result = AnalyticsRegistry.getInstance(writeKey)
+        assert(result == analytics)
+    }
+
+    @Test
+    fun `given analytics instance with the write key exists, when getInstance is called with that write key, then the Analytics instance should be returned`() {
+        AnalyticsRegistry.register(writeKey, analytics)
+
+        val result = AnalyticsRegistry.getInstance(writeKey)
+        assert(result == analytics)
+    }
+
+    @Test
+    fun `given analytics instance with the writeKey doesn't exists, when getInstance is called with that unregistered writeKey, then null should be returned`() {
+        AnalyticsRegistry.register(writeKey, analytics)
+
+        val result = AnalyticsRegistry.getInstance("unRegisteredWriteKey")
+        assert(result == null)
+    }
+}

--- a/android/src/test/java/com/rudderstack/android/android/RudderAnalyticsTest.kt
+++ b/android/src/test/java/com/rudderstack/android/android/RudderAnalyticsTest.kt
@@ -16,8 +16,9 @@ package com.rudderstack.android.android
 
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import com.rudderstack.android.AnalyticsRegistry
 import com.rudderstack.android.ConfigurationAndroid
-import com.rudderstack.android.RudderAnalytics
+import com.rudderstack.android.createInstance
 import com.rudderstack.android.currentConfigurationAndroid
 import com.rudderstack.android.setAnonymousId
 import com.rudderstack.core.Analytics
@@ -34,22 +35,100 @@ import org.robolectric.annotation.Config
 @RunWith(
     RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.P])class RudderAnalyticsTest {
-    private lateinit var analytics: Analytics
+    val writeKey = "writeKey"
 
     @Before
-    fun setup() {
-        analytics = RudderAnalytics("testKey", ConfigurationAndroid(
-            ApplicationProvider.getApplicationContext(),
-            JacksonAdapter()
-        ))
+    fun setUp() {
+        AnalyticsRegistry.clear()
     }
 
     @Test
     fun `test put anonymous id`() {
+        val analytics = createInstance("testKey", ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
         analytics.setAnonymousId("anon_id")
         MatcherAssert.assertThat(
             analytics.currentConfigurationAndroid, allOf(Matchers.isA(ConfigurationAndroid::class.java),
                 Matchers.hasProperty("anonymousId", Matchers.equalTo("anon_id"))
         ))
+    }
+
+    @Test
+    fun `when writeKey and configuration is passed, then createInstance should return Analytics instance`() {
+        val analytics = createInstance(writeKey, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        MatcherAssert.assertThat(analytics, Matchers.isA(Analytics::class.java))
+    }
+
+    @Test
+    fun `when multiple instances are created with different writeKeys, then the instances should be different`() {
+        val writeKey2 = "writeKey2"
+        val analytics = createInstance(writeKey, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        val analytics2 = createInstance(writeKey2, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        MatcherAssert.assertThat(analytics, Matchers.isA(Analytics::class.java))
+        MatcherAssert.assertThat(analytics2, Matchers.isA(Analytics::class.java))
+        assert(analytics != analytics2)
+    }
+
+    @Test
+    fun `given instance is already created with the writeKey, when createInstance is called with same write key, then the previous instance should be returned`() {
+        val analytics = createInstance(writeKey, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        val analytics2 = createInstance(writeKey, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        MatcherAssert.assertThat(analytics, Matchers.isA(Analytics::class.java))
+        MatcherAssert.assertThat(analytics2, Matchers.isA(Analytics::class.java))
+        assert(analytics == analytics2)
+    }
+
+    @Test
+    fun `given instance is already created with the writeKey, when getInstance is called with that write key, then the Analytics instance should be returned`() {
+        val analytics = createInstance(writeKey, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        val result = AnalyticsRegistry.getInstance(writeKey)
+        assert(result == analytics)
+    }
+
+    @Test
+    fun `given multiple instances are already created with different writeKeys, when getInstance is called with those write keys, then the Analytics instances should be returned`() {
+        val writeKey2 = "writeKey2"
+        val analytics = createInstance(writeKey, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        val analytics2 = createInstance(writeKey2, ConfigurationAndroid(
+            ApplicationProvider.getApplicationContext(),
+            JacksonAdapter()
+        ))
+
+        val result1 = AnalyticsRegistry.getInstance(writeKey)
+        val result2 = AnalyticsRegistry.getInstance(writeKey2)
+
+        assert(result1 == analytics)
+        assert(result2 == analytics2)
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@commitlint/cli": "17.7.2",
         "@commitlint/config-conventional": "17.7.0",
         "@digitalroute/cz-conventional-changelog-for-jira": "8.0.1",
-        "@jnxplus/nx-gradle": "0.6.1",
+        "@jnxplus/nx-gradle": "0.40.1-2",
         "@jscutlery/semver": "3.1.0",
         "@nx/workspace": "16.10.0",
         "commitizen": "4.3.0",
@@ -572,45 +572,372 @@
       }
     },
     "node_modules/@jnxplus/common": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@jnxplus/common/-/common-0.9.1.tgz",
-      "integrity": "sha512-e1Ev0vbWCPd4J8hSfAYD260QwqRDx4M8FJcYBTzzHg0RjH8JoEE9UecGJshNrvY/ZifgLeyVEiUU3xuC5GNpgQ==",
+      "version": "0.40.1-2",
+      "resolved": "https://registry.npmjs.org/@jnxplus/common/-/common-0.40.1-2.tgz",
+      "integrity": "sha512-szbw+3TNXxAT62Fw0V7+NS0tE43gzOcV6QJzn9Jahm0pqz6QT0t7D9NT2q98BUY9uOVW20UE55qBCFx7lYcIgQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "2.5.0"
-      },
-      "peerDependencies": {
-        "@nx/devkit": ">=16.0.0"
+        "@nx/devkit": ">=17.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@jnxplus/gradle": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@jnxplus/gradle/-/gradle-0.13.2.tgz",
-      "integrity": "sha512-Lq4GrzKPy2RZOq44yUSOTWpCKuL7pZ1QUFB1qy6Dv3y3tW3tzQ1U6v73DT6tCKrdWzSCkMVOzuqcE1T7EKyOkw==",
+    "node_modules/@jnxplus/common/node_modules/@nrwl/devkit": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.0.8.tgz",
+      "integrity": "sha512-cKtXq2I/3y/t1I+jMn8XVfhtSjGxJHKGSmxStMdRPMcUim8iaS2V3fDUdF2CGrXrtbmDtYwBC8413YY+nVh0Gw==",
       "dev": true,
       "dependencies": {
-        "@jnxplus/common": "0.9.1",
-        "tslib": "2.5.0"
+        "@nx/devkit": "18.0.8"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/devkit": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.0.8.tgz",
+      "integrity": "sha512-df56bzmhF8yhVCCChe0ATjCsc9r9SNcpks5/bABGqR91vHVGfsz0H33RYO7P2jrPwFBRYnf+aWWFY1d6NpEdxw==",
+      "dev": true,
+      "dependencies": {
+        "@nrwl/devkit": "18.0.8",
+        "ejs": "^3.1.7",
+        "enquirer": "~2.3.6",
+        "ignore": "^5.0.4",
+        "semver": "^7.5.3",
+        "tmp": "~0.2.1",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
       },
       "peerDependencies": {
-        "@nx/devkit": ">=16.0.0"
+        "nx": ">= 16 <= 18"
       }
     },
     "node_modules/@jnxplus/nx-gradle": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@jnxplus/nx-gradle/-/nx-gradle-0.6.1.tgz",
-      "integrity": "sha512-L4aj/QAUizu3iLhidzeB5KZWrsQSeEx2ss8m5gg5/GvlI1ubEUEobNiHT5GlS8jkxcU9TRdhS+d6xI1iwf8EgA==",
+      "version": "0.40.1-2",
+      "resolved": "https://registry.npmjs.org/@jnxplus/nx-gradle/-/nx-gradle-0.40.1-2.tgz",
+      "integrity": "sha512-ZtAMukkeZeygXSgRbyXN0YptU8Zv0cTs08GFTiRX2dC8JOBr7SaMttGApCnDdwxvKNsDR7LVOmyVLIqpkNDzAA==",
+      "dev": true,
+      "dependencies": {
+        "@jnxplus/common": "0.40.1-2",
+        "@nx/devkit": ">=17.0.0",
+        "nx": ">=17.0.0",
+        "smol-toml": "^1.1.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nrwl/devkit": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.0.8.tgz",
+      "integrity": "sha512-cKtXq2I/3y/t1I+jMn8XVfhtSjGxJHKGSmxStMdRPMcUim8iaS2V3fDUdF2CGrXrtbmDtYwBC8413YY+nVh0Gw==",
+      "dev": true,
+      "dependencies": {
+        "@nx/devkit": "18.0.8"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nrwl/tao": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.0.8.tgz",
+      "integrity": "sha512-zBzdv9mGBaWtBbujbLCVzG7ZI5npUg9fnUz8VtjN6jydAQEL/Uqj5mPlFYQPPBAw2xwF8TL9ZX/rOoAWHnJtjw==",
+      "dev": true,
+      "dependencies": {
+        "nx": "18.0.8",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "tao": "index.js"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/devkit": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.0.8.tgz",
+      "integrity": "sha512-df56bzmhF8yhVCCChe0ATjCsc9r9SNcpks5/bABGqR91vHVGfsz0H33RYO7P2jrPwFBRYnf+aWWFY1d6NpEdxw==",
+      "dev": true,
+      "dependencies": {
+        "@nrwl/devkit": "18.0.8",
+        "ejs": "^3.1.7",
+        "enquirer": "~2.3.6",
+        "ignore": "^5.0.4",
+        "semver": "^7.5.3",
+        "tmp": "~0.2.1",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
+      },
+      "peerDependencies": {
+        "nx": ">= 16 <= 18"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-darwin-arm64": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.0.8.tgz",
+      "integrity": "sha512-B2vX90j1Ex9Mki/Fai45UJ0r7mPc/xLBzQYQ9MFI2XoUXKhYl5BVBfJ+EbJ2PBcIXAnp44qY0wyxEpp+8Glxcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-darwin-x64": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.0.8.tgz",
+      "integrity": "sha512-nC172j4LwOqc22BtJGsrjPYGhZ6EFXhYi0ceb6yzEA1Z32Wl98OXbAcbbhyEcuL3iYI9VrZgzAAzIUo7l4injw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-freebsd-x64": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.0.8.tgz",
+      "integrity": "sha512-Qoz668WMB6nxdMFG5X88B7W72+d5K/95XEFKY2022EPm88DQFFcJAfdkMrRkeO3yBJtwLAAK+Jyni9uAfOXzGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.0.8.tgz",
+      "integrity": "sha512-0RTuJTaAmE7Xjc0P0DIbbYEhPGBILCii2nOz6vwTEzIqxSMgXW4T1g1zSDKCiUUyS6HVffGvCTNvuHuoYY2DMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.0.8.tgz",
+      "integrity": "sha512-fmwsrDeeY44f6cCnfrXNuvFEzqvD/A5yg3TVwZoKldWRAG5gexj4AWpBHqgGTcCj6ky1NGxnlaktKC5geGhJhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.0.8.tgz",
+      "integrity": "sha512-jz1dzQlrfZteJdsEJ1MbjI7m2jkBLhLe5y9x+96/KgmJbCV7LD9RLevWIzz7FDuhfJziMOoSrGdaW47G13p/Fw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.0.8.tgz",
+      "integrity": "sha512-eq2AAZN4fsjhABtU76eroFHcNK6QWo4eMAH7tcZUoGLwfBAo+wPYggxm9LNZ5weKVxwqySHavlXd5rNA26WrbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.0.8.tgz",
+      "integrity": "sha512-FBHVJ0DtBqQynbQImg1kc9/WfRGSvbRNzaqI2rO/zO0j2BeT9BQ8byTn2EiMBxz72LSbqEmtQtqe5w50hAsKcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.0.8.tgz",
+      "integrity": "sha512-qphQIIfwAR03s7ifPVc0XhjdOeep2hOoZN2jN5ShG1QD/DIipNnMrRK21M6JcoP7soRPpkJFlI5Yaleh9/EJhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.0.8.tgz",
+      "integrity": "sha512-XP8hle+cPNH5n18iTM7l0q07zEdvoPcHYVr5IoYOA54Ke9ZUxau4owUeok2HhLr61o2u0CTwf1vWoV+Y1AUAdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/nx": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-18.0.8.tgz",
+      "integrity": "sha512-IhzRLCZaiR9zKGJ3Jm79bhi8nOdyRORQkFc/YDO6xubLSQ5mLPAeg789Q/SlGRzU5oMwLhm5D/gvvMJCAvUmXQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@jnxplus/common": "0.9.1",
-        "@jnxplus/gradle": "0.13.2",
-        "prettier": "^2.8.7",
-        "prettier-plugin-java": "^2.1.0",
-        "tslib": "2.5.0"
+        "@nrwl/tao": "18.0.8",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "3.0.0-rc.46",
+        "@zkochan/js-yaml": "0.0.6",
+        "axios": "^1.6.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^8.0.1",
+        "dotenv": "~16.3.1",
+        "dotenv-expand": "~10.0.0",
+        "enquirer": "~2.3.6",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "fs-extra": "^11.1.0",
+        "ignore": "^5.0.4",
+        "jest-diff": "^29.4.1",
+        "js-yaml": "4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "~2.0.3",
+        "minimatch": "9.0.3",
+        "node-machine-id": "1.1.12",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "ora": "5.3.0",
+        "semver": "^7.5.3",
+        "string-width": "^4.2.3",
+        "strong-log-transformer": "^2.1.0",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js",
+        "nx-cloud": "bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "18.0.8",
+        "@nx/nx-darwin-x64": "18.0.8",
+        "@nx/nx-freebsd-x64": "18.0.8",
+        "@nx/nx-linux-arm-gnueabihf": "18.0.8",
+        "@nx/nx-linux-arm64-gnu": "18.0.8",
+        "@nx/nx-linux-arm64-musl": "18.0.8",
+        "@nx/nx-linux-x64-gnu": "18.0.8",
+        "@nx/nx-linux-x64-musl": "18.0.8",
+        "@nx/nx-win32-arm64-msvc": "18.0.8",
+        "@nx/nx-win32-x64-msvc": "18.0.8"
       },
       "peerDependencies": {
-        "@nx/devkit": ">=16.3.0"
+        "@swc-node/register": "^1.8.0",
+        "@swc/core": "^1.3.85"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -706,12 +1033,6 @@
         "tao": "index.js"
       }
     },
-    "node_modules/@nrwl/tao/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@nrwl/workspace": {
       "version": "16.10.0",
       "resolved": "https://registry.npmjs.org/@nrwl/workspace/-/workspace-16.10.0.tgz",
@@ -753,12 +1074,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@nx/devkit/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@nx/nx-darwin-arm64": {
       "version": "16.10.0",
@@ -933,12 +1248,6 @@
         "yargs-parser": "21.1.1"
       }
     },
-    "node_modules/@nx/workspace/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@parcel/watcher": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
@@ -1081,12 +1390,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.6",
@@ -1261,12 +1564,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -1459,15 +1762,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/chevrotain": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.5.0.tgz",
-      "integrity": "sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==",
-      "dev": true,
-      "dependencies": {
-        "regexp-to-ast": "0.4.0"
-      }
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -2525,9 +2819,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -3215,16 +3509,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/java-parser": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.0.5.tgz",
-      "integrity": "sha512-AwieTO24Itcu0GgP9pBXs8gkqBtkmReclpBgXF4NkbIjdS7cn7hqpebjTmb5ouYYLFR+m3yh5fR3nW1NRrthdg==",
-      "dev": true,
-      "dependencies": {
-        "chevrotain": "6.5.0",
-        "lodash": "4.17.21"
       }
     },
     "node_modules/jest-diff": {
@@ -4032,12 +4316,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/nx/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4256,47 +4534,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-plugin-java": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-2.3.1.tgz",
-      "integrity": "sha512-OYn8skqKnE5YUVL8f2ocayA6XCJK8PqsEz3pfATbDqzgdaSYDLhE/s8KrXrX9gj8KXIG6Wx0CMoXTNH8+ED22w==",
-      "dev": true,
-      "dependencies": {
-        "java-parser": "2.0.5",
-        "lodash": "4.17.21",
-        "prettier": "3.0.3"
-      }
-    },
-    "node_modules/prettier-plugin-java/node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -4545,12 +4782,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/regexp-to-ast": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
-      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
-      "dev": true
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4675,12 +4906,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4748,6 +4973,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/smol-toml": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.1.4.tgz",
+      "integrity": "sha512-Y0OT8HezWsTNeEOSVxDnKOW/AyNXHQ4BwJNbAXlLTF5wWsBvrcHhIkE5Rf8kQMLmgf7nDX3PVOlgC6/Aiggu3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 8"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -5106,9 +5341,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@jscutlery/semver": "3.1.0",
     "commitizen": "4.3.0",
     "commitlint": "17.7.2",
-    "@jnxplus/nx-gradle": "0.6.1",
+    "@jnxplus/nx-gradle": "0.40.1-2",
     "@nx/workspace": "16.10.0",
     "nx": "16.10.0"
   },


### PR DESCRIPTION
## Description

- Add support for initialising the SDK multiple times using different writeKeys.

## Fixed

- I also noticed some issues with the `npm ci` command, due to which the unit test action is failing (refer [here](https://github.com/rudderlabs/rudder-sdk-android/pull/227)). So, to fix that, I update the version of one of the npm packages: https://www.npmjs.com/package/@jnxplus/nx-gradle to the latest version `0.40.1-2`.

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
