### PR TITLE
fix: Application Opened event not being fired

### DIFF
--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/ActivityBroadcasterPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/ActivityBroadcasterPlugin.kt
@@ -36,16 +36,16 @@ internal class ActivityBroadcasterPlugin(
     private val lifecycleCallback by lazy {
         object : Application.ActivityLifecycleCallbacks {
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-                if(analytics?.currentConfigurationAndroid?.trackLifecycleEvents == true  &&
-                    activityCount.get() == 0) {
-                    broadCastApplicationStart()
-                }
             }
 
             override fun onActivityStarted(activity: Activity) {
                 incrementActivityCount()
                 if (analytics?.currentConfigurationAndroid?.recordScreenViews == true) {
                     broadcastActivityStart(activity)
+                }
+                if(analytics?.currentConfigurationAndroid?.trackLifecycleEvents == true  &&
+                    activityCount.get() == 1) {
+                    broadCastApplicationStart()
                 }
             }
 


### PR DESCRIPTION
**Fixes** # (*issue*)

- When the app moves from background to foreground the `Application Opened` event was not fired. This PR attempts to fix that.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
