### PR TITLE
feat: updates agp to 8.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.4.2"
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,6 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=Rudderstack
 POM_DEVELOPER_NAME=Rudderstack, Inc.
 VERSION_NAME=1.0.0
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/mainview/MainViewModel.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/mainview/MainViewModel.kt
@@ -8,7 +8,6 @@ import com.rudderstack.android.sampleapp.analytics.RudderAnalyticsUtils.primaryA
 import com.rudderstack.android.sampleapp.analytics.RudderAnalyticsUtils.secondaryAnalytics
 import com.rudderstack.android.utilities.endSession
 import com.rudderstack.android.utilities.startSession
-import com.rudderstack.core.Analytics
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderOptions
 import com.rudderstack.models.GroupTraits
@@ -30,14 +29,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _loggingInterceptor by lazy {
         object : Plugin {
-            private var _instanceName: String? = null
+            private var logsName: String = "Sample app"
 
             override fun intercept(chain: Plugin.Chain): Message {
                 val msg = chain.message()
                 _state.update { state ->
                     state.copy(
                         logDataList = state.logDataList + LogData(
-                            Date(), "from $_instanceName, msg: $msg"
+                            Date(), "from $logsName, msg: $msg"
                         )
                     )
                 }


### PR DESCRIPTION
### [Ticket](https://linear.app/rudderstack/issue/SDK-1514/update-android-gradle-plugin-to-822)

Branch will be rebased against `feat/android` when the base branch will be merged.

## Description 
In this PR, we are updating the Android Gradle plugin to the latest version, and applying a very small fix with an incompatibility that was caused due to this update.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Implementation Details
- Updates project build.gradle agp to the 8.2.2.
- Updates `gradle/wrapper/gradle-wrapper.properties` to the 8.2.2
- Adds some properties in `gradle.properties`


## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [x] I have made corresponding changes to the documentation

### Screenshots
- Kotlin Sample application builds as normal!
<img src="https://github.com/rudderlabs/rudder-sdk-android/assets/6973204/3e767ded-4e0f-4caf-9465-2c82df9fdcb0" height="400" />

