### PR TITLE
fix: unit test cases

### DIFF
--- a/.github/workflows/build-v2.yml
+++ b/.github/workflows/build-v2.yml
@@ -2,15 +2,14 @@ name: CI for v2
 
 on:
   push:
-    branches: [ 'master-v2' ]
+    branches: ["master-v2"]
   pull_request:
-    branches: [ 'master-v2', 'develop-v2' ]
-    types: [ 'opened', 'reopened', 'edited', 'synchronize' ]
+    branches: ["master-v2", "develop-v2"]
+    types: ["opened", "reopened", "edited", "synchronize"]
   workflow_dispatch:
 
 jobs:
   cancel_previous-v2:
-
     runs-on: ubuntu-latest
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
@@ -29,8 +28,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -38,8 +37,8 @@ jobs:
       - name: Set Node 16
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install node_modules
         run: |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,11 +42,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = jvmTarget = '17'
     }
     testOptions {
         unitTests {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = jvmTarget = '17'
+        jvmTarget = '17'
     }
     testOptions {
         unitTests {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,15 +38,15 @@ android {
         }
     }
   kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,15 +18,15 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 

--- a/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
+++ b/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
@@ -17,17 +17,23 @@ package com.rudderstack.core
 import com.rudderstack.core.internal.CentralPluginChain
 import com.rudderstack.models.Message
 import com.rudderstack.models.TrackMessage
-import io.mockk.MockKAnnotations
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
-
-import io.mockk.mockk
-import io.mockk.slot
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Testing flow of control through plugins.
@@ -35,18 +41,29 @@ import io.mockk.slot
  * Avoiding spying of objects.
  *
  */
+@RunWith(MockitoJUnitRunner::class)
 class CentralPluginChainTest {
 
-    @MockK
+    companion object{
+        //Plugins should be called in this order
+        private const val SUB_PLUGIN_1_1_SL_NO = 1
+        private const val SUB_PLUGIN_2_1_SL_NO = 2
+        private const val MAIN_PLUGIN_1_SL_NO = 3
+        private const val SUB_PLUGIN_1_2_SL_NO = 4
+        private const val MAIN_PLUGIN_2_SL_NO = 5
+        private const val MAIN_PLUGIN_3_SL_NO = 6
+        private const val TOTAL_NO_OF_CALLS = 7
+    }
+    @Mock
     lateinit var mockPlugin1: Plugin
 
-    @MockK
+    @Mock
     lateinit var mockPlugin2: Plugin
 
-    @MockK
+    @Mock
     lateinit var mockDestinationPlugin: DestinationPlugin<*>
 
-    private val message: Message = TrackMessage.create(
+    private val mockMessage: Message = TrackMessage.create(
         "ev-1", RudderUtils.timeStamp,
         traits = mapOf(
             "age" to 31,
@@ -61,114 +78,134 @@ class CentralPluginChainTest {
 
     private lateinit var centralPluginChain: CentralPluginChain
 
-    @Before
-    fun setup() {
-        MockKAnnotations.init(this, relaxed = true)
-        // Mock the behavior of plugins and destination plugin
-        every { mockPlugin1.intercept(any()) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
-        }
-        every { mockPlugin2.intercept(any()) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
-        }
-        every { mockDestinationPlugin.intercept(any()) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
-        }
+    /*private val dummyPlugin1  = BaseDestinationPlugin<Any>("dummy1") {
+        val msg = it.message()
+        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_1_SL_NO))
+        //message and original message should be different for destination plugin
+        assertThat(msg, not(it.originalMessage))
+        it.proceed(it.originalMessage)
+    }
+    private val dummyPlugin2 = BaseDestinationPlugin<Any>("dummy2") {
+        val msg = it.message()
+        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_2_SL_NO))
 
+        //message and original message should be different for destination plugin
+        assertThat(msg, not(it.originalMessage))
+        //destination plugins should always call proceed on original message to discard changes.
+        it.proceed(it.originalMessage)
+    }
+    private val dummyPlugin3 = Plugin {
+        val msg = it.message()
+        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_3_SL_NO))
+        it.proceed(msg)
+    }*/
+    @Before
+    fun setup(){
+        // Mock the behavior of plugins and destination plugin
+        whenever(mockPlugin1.intercept(any())).thenAnswer{
+            val chain = it.arguments[0] as CentralPluginChain
+            chain.proceed(mockMessage)
+        }
+        whenever(mockPlugin2.intercept(any())).thenAnswer{
+            val chain = it.arguments[0] as CentralPluginChain
+            chain.proceed(mockMessage)
+        }
+        whenever(mockDestinationPlugin.intercept(any())).thenAnswer{
+            val chain = it.arguments[0] as CentralPluginChain
+            chain.proceed(mockMessage)
+        }
         // Initialize the list of plugins for testing
         val plugins = listOf(mockPlugin1, mockPlugin2, mockDestinationPlugin)
-        centralPluginChain = CentralPluginChain(message, plugins, originalMessage = message)
+        centralPluginChain = CentralPluginChain(mockMessage, plugins, originalMessage = mockMessage)
+//        whenever(mockMessage.copy()).thenReturn(mockMessage)
     }
-
     @Test
     fun testMessage() {
-        assertThat(centralPluginChain.message(), equalTo(message))
+        assertThat(centralPluginChain.message(), equalTo(mockMessage))
     }
 
     @Test
     fun testProceed() {
-        // Verify interactions
-        val chainCaptor1 = slot<CentralPluginChain>()
-        every { mockPlugin1.intercept(capture(chainCaptor1)) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
-        }
 
-        val chainCaptor2 = slot<CentralPluginChain>()
-        every { mockPlugin2.intercept(capture(chainCaptor2)) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
-        }
-
-        val chainCaptor3 = slot<CentralPluginChain>()
-        every { mockDestinationPlugin.intercept(capture(chainCaptor3)) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
-        }
 
         // Call the method under test
-        val resultMessage = centralPluginChain.proceed(message)
+        val resultMessage = centralPluginChain.proceed(mockMessage)
 
-        val chain1 = chainCaptor1.captured
+        // Verify interactions
+        val chainCaptor1 = argumentCaptor<CentralPluginChain>()
+        verify(mockPlugin1).intercept(chainCaptor1.capture())
+        val chain1 = chainCaptor1.lastValue
         assertThat(chain1.index, `is`(1))
         assertThat(chain1.plugins.size, `is`(3))
-        assertThat(chain1.originalMessage, equalTo(message))
+        assertThat(chain1.originalMessage, equalTo(mockMessage))
 
-        val chain2 = chainCaptor2.captured
+        val chainCaptor2 = argumentCaptor<CentralPluginChain>()
+        verify(mockPlugin2).intercept(chainCaptor2.capture())
+        val chain2 = chainCaptor2.lastValue
         assertThat(chain2.index, `is`(2))
         assertThat(chain2.plugins.size, `is`(3))
-        assertThat(chain2.originalMessage, equalTo(message))
+        assertThat(chain2.originalMessage, equalTo(mockMessage))
 
-        val chain3 = chainCaptor3.captured
+        val chainCaptor3 = argumentCaptor<CentralPluginChain>()
+        verify(mockDestinationPlugin).intercept(chainCaptor3.capture())
+        val chain3 = chainCaptor3.lastValue
         assertThat(chain3.index, `is`(3))
         assertThat(chain3.plugins.size, `is`(3))
-        assertThat(chain3.originalMessage, equalTo(message))
-
+        assertThat(chain3.originalMessage, equalTo(mockMessage))
         // Assert the result
-        assertThat(resultMessage, equalTo(message))
+        assertThat(resultMessage, equalTo(mockMessage))
     }
 
     @Test(expected = IllegalStateException::class)
     fun testProceedTwice() {
 
         // Call the method under test twice
-        centralPluginChain.proceed(message)
-        centralPluginChain.proceed(message)
+        centralPluginChain.proceed(mockMessage)
+        centralPluginChain.proceed(mockMessage)
     }
-
     @Test
-    fun testCentralPluginChainWithSubPlugins() {
-        val subChainCaptor1 = slot<CentralPluginChain>()
-        val subChainCaptor2 = slot<CentralPluginChain>()
-
-        val subPlugin1 = mockk<DestinationPlugin.DestinationInterceptor>()
-        every { subPlugin1.intercept(capture(subChainCaptor1)) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
+    fun testCentralPluginChainWithSubPlugins(){
+        val subPlugin1 = mock<DestinationPlugin.DestinationInterceptor>()
+        whenever(subPlugin1.intercept(any())).thenAnswer{
+            val chain = it.arguments[0] as CentralPluginChain
+            chain.proceed(mockMessage)
         }
-
-        val subPlugin2 = mockk<DestinationPlugin.DestinationInterceptor>()
+        val subPlugin2 = mock<DestinationPlugin.DestinationInterceptor>()
         // Mock the behavior of plugins and destination plugin
-        every { subPlugin2.intercept(capture(subChainCaptor2)) } answers {
-            val chain = arg<CentralPluginChain>(0)
-            chain.proceed(message)
+        whenever(subPlugin2.intercept(any())).thenAnswer{
+            val chain = it.arguments[0] as CentralPluginChain
+            chain.proceed(mockMessage)
         }
+        whenever(mockDestinationPlugin.subPlugins).thenReturn(listOf(subPlugin1, subPlugin2))
 
-        every { mockDestinationPlugin.subPlugins } returns listOf(subPlugin1, subPlugin2)
-
-        centralPluginChain.proceed(message)
-
-        val chain1 = subChainCaptor1.captured
+        centralPluginChain.proceed(mockMessage)
+        // Verify interactions
+        val subChainCaptor1 = argumentCaptor<CentralPluginChain>()
+        verify(subPlugin1).intercept(subChainCaptor1.capture())
+        val chain1 = subChainCaptor1.lastValue
         assertThat(chain1.index, `is`(1)) // index should be 1 for sub plugins
         assertThat(chain1.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
-        assertThat(chain1.originalMessage, equalTo(message))
+        assertThat(chain1.originalMessage, equalTo(mockMessage))
 
-        val chain2 = subChainCaptor2.captured
+        val subChainCaptor2 = argumentCaptor<CentralPluginChain>()
+        verify(subPlugin2).intercept(subChainCaptor2.capture())
+        val chain2 = subChainCaptor2.lastValue
         assertThat(chain2.index, `is`(2)) // index should be 2 for sub plugins
         assertThat(chain2.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
-        assertThat(chain2.originalMessage, equalTo(message))
+        assertThat(chain2.originalMessage, equalTo(mockMessage))
     }
+
+    /*@Test
+    fun testCentralPluginChain(){
+        val dummyMsg = TrackMessage.create("message_id",
+            anonymousId = "anon_id", timestamp = Date().toString())
+        CentralPluginChain(dummyMsg, listOf(
+            dummyPlugin1, dummyPlugin2, dummyPlugin3) )
+            .proceed(dummyMsg)
+        //check if all plugins and sub plugins are called
+        assertThat(enteredPluginNo , `is`(TOTAL_NO_OF_CALLS))
+    }
+
+*/
+
 }

--- a/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
+++ b/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
@@ -16,24 +16,17 @@ package com.rudderstack.core
 
 import com.rudderstack.core.internal.CentralPluginChain
 import com.rudderstack.models.Message
-import com.rudderstack.models.TrackMessage
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
-import java.util.*
-import java.util.concurrent.atomic.AtomicInteger
+
+import io.mockk.mockk
+import io.mockk.slot
 
 /**
  * Testing flow of control through plugins.
@@ -41,74 +34,45 @@ import java.util.concurrent.atomic.AtomicInteger
  * Avoiding spying of objects.
  *
  */
-@RunWith(MockitoJUnitRunner::class)
 class CentralPluginChainTest {
 
-    companion object{
-        //Plugins should be called in this order
-        private const val SUB_PLUGIN_1_1_SL_NO = 1
-        private const val SUB_PLUGIN_2_1_SL_NO = 2
-        private const val MAIN_PLUGIN_1_SL_NO = 3
-        private const val SUB_PLUGIN_1_2_SL_NO = 4
-        private const val MAIN_PLUGIN_2_SL_NO = 5
-        private const val MAIN_PLUGIN_3_SL_NO = 6
-        private const val TOTAL_NO_OF_CALLS = 7
-    }
-    @Mock
+    @MockK
     lateinit var mockPlugin1: Plugin
 
-    @Mock
+    @MockK
     lateinit var mockPlugin2: Plugin
 
-    @Mock
+    @MockK
     lateinit var mockDestinationPlugin: DestinationPlugin<*>
 
-    @Mock
+    @MockK
     lateinit var mockMessage: Message
 
     private lateinit var centralPluginChain: CentralPluginChain
 
-    /*private val dummyPlugin1  = BaseDestinationPlugin<Any>("dummy1") {
-        val msg = it.message()
-        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_1_SL_NO))
-        //message and original message should be different for destination plugin
-        assertThat(msg, not(it.originalMessage))
-        it.proceed(it.originalMessage)
-    }
-    private val dummyPlugin2 = BaseDestinationPlugin<Any>("dummy2") {
-        val msg = it.message()
-        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_2_SL_NO))
-
-        //message and original message should be different for destination plugin
-        assertThat(msg, not(it.originalMessage))
-        //destination plugins should always call proceed on original message to discard changes.
-        it.proceed(it.originalMessage)
-    }
-    private val dummyPlugin3 = Plugin {
-        val msg = it.message()
-        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_3_SL_NO))
-        it.proceed(msg)
-    }*/
     @Before
-    fun setup(){
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
         // Mock the behavior of plugins and destination plugin
-        whenever(mockPlugin1.intercept(any())).thenAnswer{
-            val chain = it.arguments[0] as CentralPluginChain
+        every { mockPlugin1.intercept(any()) } answers {
+            val chain = arg<CentralPluginChain>(0)
             chain.proceed(mockMessage)
         }
-        whenever(mockPlugin2.intercept(any())).thenAnswer{
-            val chain = it.arguments[0] as CentralPluginChain
+        every { mockPlugin2.intercept(any()) } answers {
+            val chain = arg<CentralPluginChain>(0)
             chain.proceed(mockMessage)
         }
-        whenever(mockDestinationPlugin.intercept(any())).thenAnswer{
-            val chain = it.arguments[0] as CentralPluginChain
+        every { mockDestinationPlugin.intercept(any()) } answers {
+            val chain = arg<CentralPluginChain>(0)
             chain.proceed(mockMessage)
         }
+
         // Initialize the list of plugins for testing
         val plugins = listOf(mockPlugin1, mockPlugin2, mockDestinationPlugin)
         centralPluginChain = CentralPluginChain(mockMessage, plugins, originalMessage = mockMessage)
-        whenever(mockMessage.copy()).thenReturn(mockMessage)
+        every { mockMessage.copy() } returns mockMessage
     }
+
     @Test
     fun testMessage() {
         assertThat(centralPluginChain.message(), equalTo(mockMessage))
@@ -116,32 +80,45 @@ class CentralPluginChainTest {
 
     @Test
     fun testProceed() {
+        // Verify interactions
+        val chainCaptor1 = slot<CentralPluginChain>()
+        every { mockPlugin1.intercept(capture(chainCaptor1)) } answers {
+            val chain = arg<CentralPluginChain>(0)
+            chain.proceed(mockMessage)
+        }
 
+        val chainCaptor2 = slot<CentralPluginChain>()
+        every { mockPlugin2.intercept(capture(chainCaptor2)) } answers {
+            val chain = arg<CentralPluginChain>(0)
+            chain.proceed(mockMessage)
+        }
+
+
+        val chainCaptor3 = slot<CentralPluginChain>()
+        every { mockDestinationPlugin.intercept(capture(chainCaptor3)) } answers {
+            val chain = arg<CentralPluginChain>(0)
+            chain.proceed(mockMessage)
+        }
 
         // Call the method under test
         val resultMessage = centralPluginChain.proceed(mockMessage)
 
-        // Verify interactions
-        val chainCaptor1 = argumentCaptor<CentralPluginChain>()
-        verify(mockPlugin1).intercept(chainCaptor1.capture())
-        val chain1 = chainCaptor1.lastValue
+        val chain1 = chainCaptor1.captured
         assertThat(chain1.index, `is`(1))
         assertThat(chain1.plugins.size, `is`(3))
         assertThat(chain1.originalMessage, equalTo(mockMessage))
 
-        val chainCaptor2 = argumentCaptor<CentralPluginChain>()
-        verify(mockPlugin2).intercept(chainCaptor2.capture())
-        val chain2 = chainCaptor2.lastValue
+        val chain2 = chainCaptor2.captured
         assertThat(chain2.index, `is`(2))
         assertThat(chain2.plugins.size, `is`(3))
         assertThat(chain2.originalMessage, equalTo(mockMessage))
 
-        val chainCaptor3 = argumentCaptor<CentralPluginChain>()
-        verify(mockDestinationPlugin).intercept(chainCaptor3.capture())
-        val chain3 = chainCaptor3.lastValue
+
+        val chain3 = chainCaptor3.captured
         assertThat(chain3.index, `is`(3))
         assertThat(chain3.plugins.size, `is`(3))
         assertThat(chain3.originalMessage, equalTo(mockMessage))
+
         // Assert the result
         assertThat(resultMessage, equalTo(mockMessage))
     }
@@ -153,49 +130,37 @@ class CentralPluginChainTest {
         centralPluginChain.proceed(mockMessage)
         centralPluginChain.proceed(mockMessage)
     }
+
     @Test
-    fun testCentralPluginChainWithSubPlugins(){
-        val subPlugin1 = mock<DestinationPlugin.DestinationInterceptor>()
-        whenever(subPlugin1.intercept(any())).thenAnswer{
-            val chain = it.arguments[0] as CentralPluginChain
+    fun testCentralPluginChainWithSubPlugins() {
+        val subChainCaptor1 = slot<CentralPluginChain>()
+        val subChainCaptor2 = slot<CentralPluginChain>()
+
+        val subPlugin1 = mockk<DestinationPlugin.DestinationInterceptor>()
+        every { subPlugin1.intercept(capture(subChainCaptor1)) } answers {
+            val chain = arg<CentralPluginChain>(0)
             chain.proceed(mockMessage)
         }
-        val subPlugin2 = mock<DestinationPlugin.DestinationInterceptor>()
+
+        val subPlugin2 = mockk<DestinationPlugin.DestinationInterceptor>()
         // Mock the behavior of plugins and destination plugin
-        whenever(subPlugin2.intercept(any())).thenAnswer{
-            val chain = it.arguments[0] as CentralPluginChain
+        every { subPlugin2.intercept(capture(subChainCaptor2)) } answers {
+            val chain = arg<CentralPluginChain>(0)
             chain.proceed(mockMessage)
         }
-        whenever(mockDestinationPlugin.subPlugins).thenReturn(listOf(subPlugin1, subPlugin2))
+
+        every { mockDestinationPlugin.subPlugins } returns listOf(subPlugin1, subPlugin2)
 
         centralPluginChain.proceed(mockMessage)
-        // Verify interactions
-        val subChainCaptor1 = argumentCaptor<CentralPluginChain>()
-        verify(subPlugin1).intercept(subChainCaptor1.capture())
-        val chain1 = subChainCaptor1.lastValue
+
+        val chain1 = subChainCaptor1.captured
         assertThat(chain1.index, `is`(1)) // index should be 1 for sub plugins
         assertThat(chain1.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
         assertThat(chain1.originalMessage, equalTo(mockMessage))
 
-        val subChainCaptor2 = argumentCaptor<CentralPluginChain>()
-        verify(subPlugin2).intercept(subChainCaptor2.capture())
-        val chain2 = subChainCaptor2.lastValue
+        val chain2 = subChainCaptor2.captured
         assertThat(chain2.index, `is`(2)) // index should be 2 for sub plugins
         assertThat(chain2.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
         assertThat(chain2.originalMessage, equalTo(mockMessage))
     }
-
-    /*@Test
-    fun testCentralPluginChain(){
-        val dummyMsg = TrackMessage.create("message_id",
-            anonymousId = "anon_id", timestamp = Date().toString())
-        CentralPluginChain(dummyMsg, listOf(
-            dummyPlugin1, dummyPlugin2, dummyPlugin3) )
-            .proceed(dummyMsg)
-        //check if all plugins and sub plugins are called
-        assertThat(enteredPluginNo , `is`(TOTAL_NO_OF_CALLS))
-    }
-
-*/
-
 }

--- a/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
+++ b/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
@@ -46,7 +46,7 @@ class CentralPluginChainTest {
     @MockK
     lateinit var mockDestinationPlugin: DestinationPlugin<*>
 
-    private val mockMessage: Message = TrackMessage.create(
+    private val message: Message = TrackMessage.create(
         "ev-1", RudderUtils.timeStamp,
         traits = mapOf(
             "age" to 31,
@@ -67,25 +67,25 @@ class CentralPluginChainTest {
         // Mock the behavior of plugins and destination plugin
         every { mockPlugin1.intercept(any()) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
         every { mockPlugin2.intercept(any()) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
         every { mockDestinationPlugin.intercept(any()) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
 
         // Initialize the list of plugins for testing
         val plugins = listOf(mockPlugin1, mockPlugin2, mockDestinationPlugin)
-        centralPluginChain = CentralPluginChain(mockMessage, plugins, originalMessage = mockMessage)
+        centralPluginChain = CentralPluginChain(message, plugins, originalMessage = message)
     }
 
     @Test
     fun testMessage() {
-        assertThat(centralPluginChain.message(), equalTo(mockMessage))
+        assertThat(centralPluginChain.message(), equalTo(message))
     }
 
     @Test
@@ -94,49 +94,49 @@ class CentralPluginChainTest {
         val chainCaptor1 = slot<CentralPluginChain>()
         every { mockPlugin1.intercept(capture(chainCaptor1)) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
 
         val chainCaptor2 = slot<CentralPluginChain>()
         every { mockPlugin2.intercept(capture(chainCaptor2)) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
 
         val chainCaptor3 = slot<CentralPluginChain>()
         every { mockDestinationPlugin.intercept(capture(chainCaptor3)) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
 
         // Call the method under test
-        val resultMessage = centralPluginChain.proceed(mockMessage)
+        val resultMessage = centralPluginChain.proceed(message)
 
         val chain1 = chainCaptor1.captured
         assertThat(chain1.index, `is`(1))
         assertThat(chain1.plugins.size, `is`(3))
-        assertThat(chain1.originalMessage, equalTo(mockMessage))
+        assertThat(chain1.originalMessage, equalTo(message))
 
         val chain2 = chainCaptor2.captured
         assertThat(chain2.index, `is`(2))
         assertThat(chain2.plugins.size, `is`(3))
-        assertThat(chain2.originalMessage, equalTo(mockMessage))
+        assertThat(chain2.originalMessage, equalTo(message))
 
         val chain3 = chainCaptor3.captured
         assertThat(chain3.index, `is`(3))
         assertThat(chain3.plugins.size, `is`(3))
-        assertThat(chain3.originalMessage, equalTo(mockMessage))
+        assertThat(chain3.originalMessage, equalTo(message))
 
         // Assert the result
-        assertThat(resultMessage, equalTo(mockMessage))
+        assertThat(resultMessage, equalTo(message))
     }
 
     @Test(expected = IllegalStateException::class)
     fun testProceedTwice() {
 
         // Call the method under test twice
-        centralPluginChain.proceed(mockMessage)
-        centralPluginChain.proceed(mockMessage)
+        centralPluginChain.proceed(message)
+        centralPluginChain.proceed(message)
     }
 
     @Test
@@ -147,28 +147,28 @@ class CentralPluginChainTest {
         val subPlugin1 = mockk<DestinationPlugin.DestinationInterceptor>()
         every { subPlugin1.intercept(capture(subChainCaptor1)) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
 
         val subPlugin2 = mockk<DestinationPlugin.DestinationInterceptor>()
         // Mock the behavior of plugins and destination plugin
         every { subPlugin2.intercept(capture(subChainCaptor2)) } answers {
             val chain = arg<CentralPluginChain>(0)
-            chain.proceed(mockMessage)
+            chain.proceed(message)
         }
 
         every { mockDestinationPlugin.subPlugins } returns listOf(subPlugin1, subPlugin2)
 
-        centralPluginChain.proceed(mockMessage)
+        centralPluginChain.proceed(message)
 
         val chain1 = subChainCaptor1.captured
         assertThat(chain1.index, `is`(1)) // index should be 1 for sub plugins
         assertThat(chain1.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
-        assertThat(chain1.originalMessage, equalTo(mockMessage))
+        assertThat(chain1.originalMessage, equalTo(message))
 
         val chain2 = subChainCaptor2.captured
         assertThat(chain2.index, `is`(2)) // index should be 2 for sub plugins
         assertThat(chain2.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
-        assertThat(chain2.originalMessage, equalTo(mockMessage))
+        assertThat(chain2.originalMessage, equalTo(message))
     }
 }

--- a/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
+++ b/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
@@ -20,11 +20,9 @@ import com.rudderstack.models.TrackMessage
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
@@ -32,8 +30,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.*
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Testing flow of control through plugins.
@@ -44,16 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(MockitoJUnitRunner::class)
 class CentralPluginChainTest {
 
-    companion object{
-        //Plugins should be called in this order
-        private const val SUB_PLUGIN_1_1_SL_NO = 1
-        private const val SUB_PLUGIN_2_1_SL_NO = 2
-        private const val MAIN_PLUGIN_1_SL_NO = 3
-        private const val SUB_PLUGIN_1_2_SL_NO = 4
-        private const val MAIN_PLUGIN_2_SL_NO = 5
-        private const val MAIN_PLUGIN_3_SL_NO = 6
-        private const val TOTAL_NO_OF_CALLS = 7
-    }
     @Mock
     lateinit var mockPlugin1: Plugin
 
@@ -78,39 +64,18 @@ class CentralPluginChainTest {
 
     private lateinit var centralPluginChain: CentralPluginChain
 
-    /*private val dummyPlugin1  = BaseDestinationPlugin<Any>("dummy1") {
-        val msg = it.message()
-        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_1_SL_NO))
-        //message and original message should be different for destination plugin
-        assertThat(msg, not(it.originalMessage))
-        it.proceed(it.originalMessage)
-    }
-    private val dummyPlugin2 = BaseDestinationPlugin<Any>("dummy2") {
-        val msg = it.message()
-        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_2_SL_NO))
-
-        //message and original message should be different for destination plugin
-        assertThat(msg, not(it.originalMessage))
-        //destination plugins should always call proceed on original message to discard changes.
-        it.proceed(it.originalMessage)
-    }
-    private val dummyPlugin3 = Plugin {
-        val msg = it.message()
-        assertThat(enteredPluginNo ++, `is`(MAIN_PLUGIN_3_SL_NO))
-        it.proceed(msg)
-    }*/
     @Before
-    fun setup(){
+    fun setup() {
         // Mock the behavior of plugins and destination plugin
-        whenever(mockPlugin1.intercept(any())).thenAnswer{
+        whenever(mockPlugin1.intercept(any())).thenAnswer {
             val chain = it.arguments[0] as CentralPluginChain
             chain.proceed(mockMessage)
         }
-        whenever(mockPlugin2.intercept(any())).thenAnswer{
+        whenever(mockPlugin2.intercept(any())).thenAnswer {
             val chain = it.arguments[0] as CentralPluginChain
             chain.proceed(mockMessage)
         }
-        whenever(mockDestinationPlugin.intercept(any())).thenAnswer{
+        whenever(mockDestinationPlugin.intercept(any())).thenAnswer {
             val chain = it.arguments[0] as CentralPluginChain
             chain.proceed(mockMessage)
         }
@@ -119,6 +84,7 @@ class CentralPluginChainTest {
         centralPluginChain = CentralPluginChain(mockMessage, plugins, originalMessage = mockMessage)
 //        whenever(mockMessage.copy()).thenReturn(mockMessage)
     }
+
     @Test
     fun testMessage() {
         assertThat(centralPluginChain.message(), equalTo(mockMessage))
@@ -126,8 +92,6 @@ class CentralPluginChainTest {
 
     @Test
     fun testProceed() {
-
-
         // Call the method under test
         val resultMessage = centralPluginChain.proceed(mockMessage)
 
@@ -158,21 +122,21 @@ class CentralPluginChainTest {
 
     @Test(expected = IllegalStateException::class)
     fun testProceedTwice() {
-
         // Call the method under test twice
         centralPluginChain.proceed(mockMessage)
         centralPluginChain.proceed(mockMessage)
     }
+
     @Test
-    fun testCentralPluginChainWithSubPlugins(){
+    fun testCentralPluginChainWithSubPlugins() {
         val subPlugin1 = mock<DestinationPlugin.DestinationInterceptor>()
-        whenever(subPlugin1.intercept(any())).thenAnswer{
+        whenever(subPlugin1.intercept(any())).thenAnswer {
             val chain = it.arguments[0] as CentralPluginChain
             chain.proceed(mockMessage)
         }
         val subPlugin2 = mock<DestinationPlugin.DestinationInterceptor>()
         // Mock the behavior of plugins and destination plugin
-        whenever(subPlugin2.intercept(any())).thenAnswer{
+        whenever(subPlugin2.intercept(any())).thenAnswer {
             val chain = it.arguments[0] as CentralPluginChain
             chain.proceed(mockMessage)
         }
@@ -194,18 +158,4 @@ class CentralPluginChainTest {
         assertThat(chain2.plugins.size, `is`(2)) //number of plugins should be 2 for sub plugins
         assertThat(chain2.originalMessage, equalTo(mockMessage))
     }
-
-    /*@Test
-    fun testCentralPluginChain(){
-        val dummyMsg = TrackMessage.create("message_id",
-            anonymousId = "anon_id", timestamp = Date().toString())
-        CentralPluginChain(dummyMsg, listOf(
-            dummyPlugin1, dummyPlugin2, dummyPlugin3) )
-            .proceed(dummyMsg)
-        //check if all plugins and sub plugins are called
-        assertThat(enteredPluginNo , `is`(TOTAL_NO_OF_CALLS))
-    }
-
-*/
-
 }

--- a/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
+++ b/core/src/test/java/com/rudderstack/core/CentralPluginChainTest.kt
@@ -82,7 +82,6 @@ class CentralPluginChainTest {
         // Initialize the list of plugins for testing
         val plugins = listOf(mockPlugin1, mockPlugin2, mockDestinationPlugin)
         centralPluginChain = CentralPluginChain(mockMessage, plugins, originalMessage = mockMessage)
-//        whenever(mockMessage.copy()).thenReturn(mockMessage)
     }
 
     @Test

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,7 +26,7 @@ ext {
             androidXTest           : "1.4.0",
             androidXTestExtJunitKtx: "1.1.3",
             mockito                : "1.10.19",
-            mockk                  : "1.12.7",
+            mockk                  : "1.13.3",
             junit                  : "4.+",
             awaitility             : "4.1.0",
             robolectric            : "4.10.3",

--- a/gsonrudderadapter/build.gradle
+++ b/gsonrudderadapter/build.gradle
@@ -17,15 +17,15 @@ plugins {
     id 'kotlin'
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 

--- a/jacksonrudderadapter/build.gradle
+++ b/jacksonrudderadapter/build.gradle
@@ -18,15 +18,15 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 apply from : "$projectDir/../dependencies.gradle"

--- a/libs/navigationplugin/build.gradle.kts
+++ b/libs/navigationplugin/build.gradle.kts
@@ -44,12 +44,12 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
 
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
         javaParameters = true
     }
     namespace = "com.rudderstack.android.navigationplugin"
@@ -61,5 +61,5 @@ dependencies {
     compileOnly(deps["navigationRuntime"].toString())
 }
 tasks.withType(type = org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs::class) {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
 }

--- a/libs/test-common/build.gradle.kts
+++ b/libs/test-common/build.gradle.kts
@@ -22,8 +22,8 @@ val deps : HashMap<String, Any> by extra
 val library : HashMap<String, String> by extra
 val projects : HashMap<String, String> by extra
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 dependencies {
     compileOnly(project(projects["core"].toString()))

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -17,15 +17,15 @@ plugins {
     id 'kotlin'
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 

--- a/models/src/main/java/com/rudderstack/models/android/RudderTraits.java
+++ b/models/src/main/java/com/rudderstack/models/android/RudderTraits.java
@@ -306,6 +306,7 @@ public class RudderTraits {
      * @param name        String
      * @param phone       String
      * @param userName    String
+     * @param title       String
      */
     public RudderTraits(Address address, String age, String birthday, Company company, String createdAt, String description, String email, String firstName, String gender, String id, String lastName, String name, String phone, String title, String userName) {
         /*Application application = RudderClient.getApplication();

--- a/moshirudderadapter/build.gradle
+++ b/moshirudderadapter/build.gradle
@@ -18,15 +18,15 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 

--- a/repository/build.gradle
+++ b/repository/build.gradle
@@ -37,15 +37,15 @@ android {
         }
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     testOptions {
         unitTests {

--- a/rudderjsonadapter/build.gradle
+++ b/rudderjsonadapter/build.gradle
@@ -18,15 +18,15 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 apply from : "$projectDir/../dependencies.gradle"

--- a/rudderreporter/build.gradle
+++ b/rudderreporter/build.gradle
@@ -23,15 +23,15 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     testOptions {
         unitTests {

--- a/samples/sample-kotlin-android/build.gradle.kts
+++ b/samples/sample-kotlin-android/build.gradle.kts
@@ -154,7 +154,6 @@ dependencies {
 
 
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.4")
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.5.4")

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -3,7 +3,7 @@ package com.rudderstack.android.sampleapp.analytics
 import android.app.Application
 import com.rudderstack.android.BuildConfig
 import com.rudderstack.android.ConfigurationAndroid
-import com.rudderstack.android.createInstance
+import com.rudderstack.android.RudderAnalytics
 import com.rudderstack.android.ruddermetricsreporterandroid.Configuration
 import com.rudderstack.android.ruddermetricsreporterandroid.DefaultRudderReporter
 import com.rudderstack.android.ruddermetricsreporterandroid.LibraryMetadata
@@ -22,7 +22,7 @@ object RudderAnalyticsUtils {
     private var _rudderReporter: RudderReporter? = null
 
     fun initialize(application: Application, listener: InitializationListener? = null) {
-        _rudderAnalytics = createInstance(
+        _rudderAnalytics = RudderAnalytics(
             writeKey = WRITE_KEY,
             initializationListener = { success, message ->
                 listener?.onAnalyticsInitialized(PRIMARY_INSTANCE_NAME, success, message)
@@ -36,7 +36,7 @@ object RudderAnalyticsUtils {
                 recordScreenViews = true,
             )
         )
-        _rudderAnalyticsSecondary = createInstance(
+        _rudderAnalyticsSecondary = RudderAnalytics(
             writeKey = WRITE_KEY_SECONDARY,
             initializationListener = { success, message ->
                 listener?.onAnalyticsInitialized(SECONDARY_INSTANCE_NAME, success, message)

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -3,7 +3,7 @@ package com.rudderstack.android.sampleapp.analytics
 import android.app.Application
 import com.rudderstack.android.BuildConfig
 import com.rudderstack.android.ConfigurationAndroid
-import com.rudderstack.android.RudderAnalytics
+import com.rudderstack.android.createInstance
 import com.rudderstack.android.ruddermetricsreporterandroid.Configuration
 import com.rudderstack.android.ruddermetricsreporterandroid.DefaultRudderReporter
 import com.rudderstack.android.ruddermetricsreporterandroid.LibraryMetadata
@@ -22,7 +22,7 @@ object RudderAnalyticsUtils {
     private var _rudderReporter: RudderReporter? = null
 
     fun initialize(application: Application, listener: InitializationListener? = null) {
-        _rudderAnalytics = RudderAnalytics(
+        _rudderAnalytics = createInstance(
             writeKey = WRITE_KEY,
             initializationListener = { success, message ->
                 listener?.onAnalyticsInitialized(PRIMARY_INSTANCE_NAME, success, message)
@@ -36,7 +36,7 @@ object RudderAnalyticsUtils {
                 recordScreenViews = true,
             )
         )
-        _rudderAnalyticsSecondary = RudderAnalytics(
+        _rudderAnalyticsSecondary = createInstance(
             writeKey = WRITE_KEY_SECONDARY,
             initializationListener = { success, message ->
                 listener?.onAnalyticsInitialized(SECONDARY_INSTANCE_NAME, success, message)

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -18,17 +18,17 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 
 apply from : "$projectDir/../dependencies.gradle"
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
     kotlinOptions.javaParameters = true
 }
 


### PR DESCRIPTION
## Description

- After upgrading to the Gradle version `8.2.2`, we noticed that unit test cases were failing, as the Gradle has a compatibility issue with an older Java version `11` (which the project was currently dependent upon). This PR bumps the Java version to `17` throughout the project to address that issue.
- Updated the Java version to `17` in GitHub action, as Gradle `8.2.2` is now dependent upon Java version `17`.
- After upgrading to Gradle version `8.2.2`, we observed that the existing test cases, which utilized `Mockito` to mock the `sealed` Message class, began to fail. So, we have resolved the code issue that was causing the unit test to fail in the `CentralPluginChainTest` class and also used the concrete Message class (instead of mocking the sealed Message class).

**Known Issue**: A few unit tests are still failing, but this issue is unrelated to the changes made in the Gradle version. The affected module is `models`. The failing test cases of this module should be addressed in this: https://github.com/rudderlabs/rudder-sdk-android/pull/400/commits/38547b6df0e923e9737f254474f32dbb303f8dfe.

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
