### PR TITLE
feat: migrate from sqlcipher legacy to latest version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     //sql-cipher
     compileOnly "net.zetetic:sqlcipher-android:4.5.6@aar"
-    compileOnly "androidx.sqlite:sqlite:2.3.1"
+    compileOnly "androidx.sqlite:sqlite:2.4.0"
 
     //test
     testImplementation('com.android.support.test:rules:1.0.2')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compileOnly 'androidx.lifecycle:lifecycle-common:2.6.1'
 
     //sql-cipher
-    compileOnly "net.zetetic:android-database-sqlcipher:4.5.4"
+    compileOnly "net.zetetic:sqlcipher-android:4.5.6@aar"
     compileOnly "androidx.sqlite:sqlite:2.3.1"
 
     //test

--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/EncryptedPersistence.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/EncryptedPersistence.java
@@ -14,8 +14,8 @@ import androidx.annotation.RequiresApi;
 
 import com.rudderstack.android.sdk.core.RudderLogger;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteOpenHelper;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import java.io.File;
 import java.util.List;
@@ -29,21 +29,21 @@ import java.util.Locale;
 public class EncryptedPersistence extends SQLiteOpenHelper implements Persistence {
     private final List<DbCloseListener> dbCloseListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
     private final DbCreateListener dbCreateListener;
-    private final String encryptPassword;
     private SQLiteDatabase initialDatabase = null;
 
 
     EncryptedPersistence(Application application, DbParams params, @Nullable DbCreateListener dbCreateListener) {
-        super(application, params.dbName, null, params.dbVersion);
-        this.encryptPassword = params.encryptPassword;
+        super(application, params.dbName, params.encryptPassword,null, params.dbVersion,
+                0, null, null, false);
         this.dbCreateListener = dbCreateListener;
     }
 
-    private SQLiteDatabase getWritableDatabase() {
+    @NonNull
+    public SQLiteDatabase getWritableDatabase() {
         if (initialDatabase != null) {
             return initialDatabase;
         }
-        return getWritableDatabase(encryptPassword);
+        return super.getWritableDatabase();
     }
 
     @Override

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation "androidx.work:work-runtime:2.7.1"
 
     //sql-cipher
-    implementation "net.zetetic:android-database-sqlcipher:4.5.4"
+    implementation "net.zetetic:sqlcipher-android:4.5.6@aar"
     implementation "androidx.sqlite:sqlite:2.3.1"
 
     // required for new life cycle methods


### PR DESCRIPTION
**Fixes** # (*issue*)
SDK-1495
fix: #413 
## why
SQL Cipher legacy version is deprecated.

This migration requires user to change the sqlcipher dependency
<img width="1154" alt="Screenshot 2024-04-16 at 5 30 22 PM" src="https://github.com/rudderlabs/rudder-sdk-android/assets/11850293/f8ae66e5-ac92-418c-8d65-77825ee6d942">

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
