### PR TITLE
fix: deep linking crash

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -12,11 +12,9 @@ import android.os.BadParcelableException;
 import android.os.Build;
 import android.text.TextUtils;
 
-import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.rudderstack.android.sdk.core.ReportManager;
 import com.rudderstack.android.sdk.core.RudderLogger;
-import com.rudderstack.android.sdk.core.RudderMessage;
 import com.rudderstack.android.sdk.core.gson.RudderGson;
 
 import java.io.File;
@@ -26,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -200,7 +197,8 @@ public class Utils {
     public static String getReferrer(Activity activity) {
         // If devices running on SDK versions greater than equal to 22
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            return activity.getReferrer().toString();
+            Uri referrer = activity.getReferrer();
+            return referrer != null ? referrer.toString() : null;
         }
         // If devices running on SDK versions greater than equal to 19
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {


### PR DESCRIPTION
## About the issue

We noticed that when `Intent.EXTRA_REFERRER` is absent in the `extras` while invoking a deep link, the SDK threw a `NullPointerException`.

## About the fix

Implemented a check to verify whether the `referrer` is `null` or not. If it's not `null`, then it is cast to a string.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
