### PR TITLE
fix: add missing proguard rules for the sqlcipher dependency

### DIFF
--- a/core/proguard-consumer-rules.pro
+++ b/core/proguard-consumer-rules.pro
@@ -31,11 +31,6 @@
 -keep class * extends com.rudderstack.rudderjsonadapter.RudderTypeAdapter
 
 # Required to ensure the DefaultPersistenceProviderFactory is not removed by Proguard
-# and works as expected even when the customer is not using encryption feature.
--dontwarn net.sqlcipher.Cursor
--dontwarn net.sqlcipher.database.SQLiteDatabase$CursorFactory
--dontwarn net.sqlcipher.database.SQLiteDatabase
--dontwarn net.sqlcipher.database.SQLiteOpenHelper
 -keep class com.rudderstack.android.sdk.core.persistence.DefaultPersistenceProviderFactory { *; }
 
 # Required for Device Mode Transformations
@@ -58,3 +53,10 @@
 # Required for DBEncryption feature using SQLCipher
 -keep class net.sqlcipher.** { *; }
 -keep class net.sqlcipher.database.* { *; }
+
+# Suppress warnings for SQLCipher classes
+-dontwarn net.zetetic.database.DatabaseErrorHandler
+-dontwarn net.zetetic.database.sqlcipher.SQLiteDatabase$CursorFactory
+-dontwarn net.zetetic.database.sqlcipher.SQLiteDatabase
+-dontwarn net.zetetic.database.sqlcipher.SQLiteDatabaseHook
+-dontwarn net.zetetic.database.sqlcipher.SQLiteOpenHelper


### PR DESCRIPTION
**Fixes** # (*issue*)

> Added missing ProGuard rules for the `SQLCipher` classes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
