### PR TITLE
fix: delete v1 files server config and flush server config

### DIFF
--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/ReinstatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/ReinstatePlugin.kt
@@ -135,6 +135,7 @@ internal class ReinstatePlugin : InfrastructurePlugin {
             }
         }
         _analytics?.androidStorage?.deleteV1SharedPreferencesFile()
+        _analytics?.androidStorage?.deleteV1ConfigFiles()
     }
 
     private fun Analytics.setUserIdFromV1() {

--- a/android/src/main/java/com/rudderstack/android/storage/AndroidStorage.kt
+++ b/android/src/main/java/com/rudderstack/android/storage/AndroidStorage.kt
@@ -85,4 +85,5 @@ interface AndroidStorage : Storage {
     fun migrateV1StorageToV2(callback: (Boolean) -> Unit)
 
     fun deleteV1SharedPreferencesFile()
+    fun deleteV1ConfigFiles()
 }

--- a/android/src/main/java/com/rudderstack/android/storage/AndroidStorageImpl.kt
+++ b/android/src/main/java/com/rudderstack/android/storage/AndroidStorageImpl.kt
@@ -113,9 +113,7 @@ class AndroidStorageImpl(
             DB_VERSION,
             providedExecutorService = storageExecutor
         )
-        messageDao = rudderDatabase?.getDao(MessageEntity::class.java, storageExecutor).also {
-            Log.e("issue","messageDao created for v2: $it")
-        }
+        messageDao = rudderDatabase?.getDao(MessageEntity::class.java, storageExecutor)
         messageDao?.addDataChangeListener(_messageDataListener)
 
     }
@@ -417,7 +415,6 @@ class AndroidStorageImpl(
     }
 
     override fun migrateV1StorageToV2Sync(): Boolean {
-        Log.e("issue","calling migrate on db: $rudderDatabase")
         return migrateV1MessagesToV2Database(application, rudderDatabase?:return false,
             jsonAdapter?:return false, logger)
     }

--- a/android/src/main/java/com/rudderstack/android/storage/FileUtils.kt
+++ b/android/src/main/java/com/rudderstack/android/storage/FileUtils.kt
@@ -86,3 +86,12 @@ internal fun fileExists(context: Context, filename: String): Boolean {
     val file = context.getFileStreamPath(filename)
     return file != null && file.exists()
 }
+
+internal fun deleteFile(context: Context, fileName: String): Boolean {
+    try {
+        val file = context.deleteFile(fileName)
+        return true
+    }catch (ex: Exception){
+        return false
+    }
+}


### PR DESCRIPTION
## Description

Made changes to remove v1 `RudderServerConfig` and `RudderFlushConfig` files, after migration.

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
