### PR TITLE
feat: sdk 1954 misc issues remove external ids and collect ad

### DIFF
--- a/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
+++ b/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
@@ -105,7 +105,7 @@ interface ConfigurationAndroid : Configuration {
             logger: Logger = AndroidLogger,
             analyticsExecutor: ExecutorService = Executors.newSingleThreadExecutor(),
             networkExecutor: ExecutorService = Executors.newCachedThreadPool(),
-            advertisingIdFetchExecutor : ExecutorService? = null,
+            advertisingIdFetchExecutor : ExecutorService? = Executors.newCachedThreadPool(),
             base64Generator: Base64Generator = AndroidUtils.defaultBase64Generator(),
             trackAutoSession: Boolean = Defaults.AUTO_SESSION_TRACKING,
             sessionTimeoutMillis: Long = Defaults.SESSION_TIMEOUT

--- a/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
+++ b/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
@@ -17,14 +17,11 @@ package com.rudderstack.android
 import android.app.Application
 import androidx.annotation.RestrictTo
 import com.rudderstack.android.internal.AndroidLogger
-import com.rudderstack.android.storage.AndroidStorage
-import com.rudderstack.android.storage.AndroidStorageImpl
 import com.rudderstack.core.Base64Generator
 import com.rudderstack.core.Configuration
 import com.rudderstack.core.Logger
 import com.rudderstack.core.RetryStrategy
-import com.rudderstack.core.RudderOptions
-import com.rudderstack.core.Storage
+import com.rudderstack.core.RudderOption
 import com.rudderstack.rudderjsonadapter.JsonAdapter
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -86,7 +83,7 @@ interface ConfigurationAndroid : Configuration {
             jsonAdapter: JsonAdapter,
             anonymousId: String?= null,
             userId: String? = null,
-            options: RudderOptions = RudderOptions.defaultOptions(),
+            options: RudderOption = RudderOption(),
             flushQueueSize: Int = Defaults.DEFAULT_FLUSH_QUEUE_SIZE,
             maxFlushInterval: Long = Defaults.DEFAULT_MAX_FLUSH_INTERVAL,
             shouldVerifySdk: Boolean = Defaults.SHOULD_VERIFY_SDK,
@@ -129,7 +126,7 @@ interface ConfigurationAndroid : Configuration {
             override val trackAutoSession: Boolean = trackAutoSession
             override val sessionTimeoutMillis: Long = sessionTimeoutMillis
             override val jsonAdapter: JsonAdapter = jsonAdapter
-            override val options: RudderOptions = options
+            override val options: RudderOption = options
             override val flushQueueSize: Int = flushQueueSize
             override val maxFlushInterval: Long = maxFlushInterval
             override val shouldVerifySdk: Boolean = shouldVerifySdk
@@ -202,7 +199,7 @@ interface ConfigurationAndroid : Configuration {
 
     override fun copy(
         jsonAdapter: JsonAdapter,
-        options: RudderOptions,
+        options: RudderOption,
         flushQueueSize: Int,
         maxFlushInterval: Long,
         shouldVerifySdk: Boolean,
@@ -235,7 +232,7 @@ interface ConfigurationAndroid : Configuration {
 
     fun copy(
         jsonAdapter: JsonAdapter = this.jsonAdapter,
-        options: RudderOptions = this.options,
+        options: RudderOption = this.options,
         flushQueueSize: Int = this.flushQueueSize,
         maxFlushInterval: Long = this.maxFlushInterval,
         shouldVerifySdk: Boolean = this.shouldVerifySdk,

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
@@ -25,6 +25,7 @@ import com.rudderstack.models.AliasMessage
 import com.rudderstack.models.IdentifyMessage
 import com.rudderstack.models.Message
 import com.rudderstack.models.MessageContext
+import com.rudderstack.models.optAddContext
 import com.rudderstack.models.traits
 import com.rudderstack.models.updateWith
 
@@ -80,10 +81,13 @@ internal class ExtractStatePlugin : Plugin {
                     }
                 }
                 is IdentifyMessage -> {
-                    if(newUserId != prevId) {
-                        replaceContext(it)
-                    } else appendContext(it)
-                    message
+                    val updatedContext = if(newUserId != prevId) {
+                        it
+                    } else {
+                        appendContextForIdentify(it)
+                    }
+                    replaceContext(updatedContext)
+                    message.copy(context = updatedContext)
                 }
                 else -> {
                     message
@@ -99,8 +103,10 @@ internal class ExtractStatePlugin : Plugin {
         }
     }
 
-    private fun appendContext(messageContext: MessageContext) {
-        _analytics?.processNewContext(  messageContext optAdd _analytics?.contextState?.value)
+    private fun appendContextForIdentify(messageContext: MessageContext) : MessageContext{
+       return _analytics?.contextState?.value?.let {
+           messageContext optAddContext it
+       }?: messageContext
     }
 
     private fun replaceContext(messageContext: MessageContext) {
@@ -150,7 +156,6 @@ internal class ExtractStatePlugin : Plugin {
         const val CONTEXT_USER_ID_KEY = "user_id"
         const val CONTEXT_USER_ID_KEY_ALIAS = "userId"
         const val CONTEXT_ID_KEY = "id"
-        const val CONTEXT_EXTERNAL_ID_KEY = "externalIds"
     }
 
 }

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
@@ -61,14 +61,20 @@ internal class FillDefaultsPlugin : Plugin {
             throw ex
         }
         //copying top level context to message context
-
-        return (this.copy(context = (
+        val newContext = (
                 // in case of alias we purposefully remove traits from context
                 _analytics?.contextState?.value?.let {
                     if (this is AliasMessage && this.userId != _analytics?.currentConfigurationAndroid?.userId) it.updateWith(
                         traits = mapOf()
                     ) else it
-                } selectiveReplace context),
+                } selectiveReplace context)?.let {
+                    if (this !is IdentifyMessage){
+                        // external ids is only supported for identify calls
+                        it.withExternalIdsRemoved()
+                    }else it
+        }
+
+        return (this.copy(context = newContext,
             anonymousId = anonId,
             userId = userId) as T)
     }

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
@@ -61,18 +61,19 @@ internal class FillDefaultsPlugin : Plugin {
             throw ex
         }
         //copying top level context to message context
-        val newContext = (
+        val newContext =
                 // in case of alias we purposefully remove traits from context
                 _analytics?.contextState?.value?.let {
                     if (this is AliasMessage && this.userId != _analytics?.currentConfigurationAndroid?.userId) it.updateWith(
                         traits = mapOf()
                     ) else it
-                } selectiveReplace context)?.let {
-                    if (this !is IdentifyMessage){
-                        // external ids is only supported for identify calls
-                        it.withExternalIdsRemoved()
-                    }else it
-        }
+                } selectiveReplace context.let {
+                    if (this !is IdentifyMessage) {
+                        // remove any external ids present in the message
+                        // this is in accordance to v1
+                        it?.withExternalIdsRemoved()
+                    } else it
+                }
 
         return (this.copy(context = newContext,
             anonymousId = anonId,
@@ -82,28 +83,6 @@ internal class FillDefaultsPlugin : Plugin {
     private infix fun MessageContext?.selectiveReplace(context: MessageContext?): MessageContext? {
         if (this == null) return context else if (context == null) return this
         return this.updateWith(context)
-    }
-
-    private infix fun MessageContext?.optAdd(context: MessageContext?): MessageContext? {
-        //this gets priority
-        if (this == null) return context
-        else if (context == null) return this
-        val newTraits = context.traits?.let {
-            (it - (this.traits?.keys ?: setOf()).toSet()) optAdd this.traits
-        } ?: traits
-        val newCustomContexts = context.customContexts?.let {
-            (it - (this.customContexts?.keys ?: setOf()).toSet()) optAdd this.customContexts
-        } ?: customContexts
-        val newExternalIds = context.externalIds?.let {
-            (it minusWrtKeys (this.externalIds ?: listOf())) + it
-        } ?: externalIds
-
-        createContext(newTraits, newExternalIds, newCustomContexts).let {
-            //add the extra info from both contexts
-            val extraThisContext = this - it.keys
-            val extraOperandContext = context - it.keys
-            return it + extraThisContext + extraOperandContext
-        }
     }
 
     override fun intercept(chain: Plugin.Chain): Message {

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/PlatformInputsPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/PlatformInputsPlugin.kt
@@ -25,6 +25,7 @@ import android.os.Build
 import android.provider.Settings
 import android.telephony.TelephonyManager
 import com.rudderstack.android.AndroidUtils
+import com.rudderstack.android.AndroidUtils.isOnClassPath
 import com.rudderstack.android.AndroidUtils.isTv
 import com.rudderstack.android.LifecycleListenerPlugin
 import com.rudderstack.android.utilities.currentConfigurationAndroid
@@ -39,10 +40,9 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Sets the context specific to Android
  *
- * @property application The application is needed to generate the required values
- * @constructor
- * Initiates the values
- *
+ * @constructor Initiates the values
+ * @property application The application is needed to generate the required
+ *     values
  */
 private const val CHANNEL = "mobile"
 
@@ -108,8 +108,24 @@ internal class PlatformInputsPlugin : Plugin, LifecycleListenerPlugin {
     }
 
     private fun Application.collectAdvertisingId() {
+        if(!isOnClassPath("com.google.android.gms.ads.identifier.AdvertisingIdClient")){
+            _analytics?.currentConfiguration?.logger?.debug(log = "Not collecting advertising ID because "
+                    + "com.google.android.gms.ads.identifier.AdvertisingIdClient "
+                    + "was not found on the classpath."
+            )
+            return
+        }
         _analytics?.currentConfigurationAndroid?.advertisingIdFetchExecutor?.submit {
-            val adId = getGooglePlayServicesAdvertisingID() ?: getAmazonFireAdvertisingID()
+            val adId = try {
+                getGooglePlayServicesAdvertisingID()
+            } catch (ex: Exception) {
+                _analytics?.currentConfiguration?.logger?.error(log = "Error collecting play services ad id", throwable = ex)
+                null
+            } ?: try { getAmazonFireAdvertisingID() } catch (ex: Exception){
+                _analytics?.currentConfiguration?.logger?.error(log = "Error collecting amazon fire ad id", throwable = ex)
+                null
+            }
+            _analytics?.currentConfiguration?.logger?.info(log = "Ad id collected is $adId")
             if (adId != null) {
                 synchronized(this) {
                     _advertisingId = adId
@@ -279,6 +295,7 @@ internal class PlatformInputsPlugin : Plugin, LifecycleListenerPlugin {
 
     override fun onShutDown() {
         super.onShutDown()
+        _analytics?.currentConfigurationAndroid?.advertisingIdFetchExecutor?.shutdownNow()
         _analytics = null
     }
 

--- a/android/src/test/java/com/rudderstack/android/plugins/ExtractStatePluginTest.kt
+++ b/android/src/test/java/com/rudderstack/android/plugins/ExtractStatePluginTest.kt
@@ -14,97 +14,183 @@
 
 package com.rudderstack.android.plugins
 
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import com.rudderstack.android.ConfigurationAndroid
 import com.rudderstack.android.internal.plugins.ExtractStatePlugin
-import com.rudderstack.core.RudderOptions
+import com.rudderstack.android.storage.AndroidStorage
+import com.rudderstack.core.Analytics
+import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderUtils
-import com.rudderstack.core.BasicStorageImpl
+import com.rudderstack.models.AliasMessage
 import com.rudderstack.models.IdentifyMessage
+import com.rudderstack.models.TrackMessage
+import com.rudderstack.models.traits
+import com.rudderstack.rudderjsonadapter.JsonAdapter
+import com.vagabond.testcommon.generateTestAnalytics
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
-/**
- * ExtractStatePlugin works for Identify and AliasMessage
- * Checking the storage validates the usage
- *
- */
-
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.P])
 class ExtractStatePluginTest {
 
-    @Test
-    fun `test identify with traits userId`(){
-        val storage = BasicStorageImpl( )
-        val options = RudderOptions.Builder().withExternalIds(listOf(mapOf(
-            "dest-1" to "dest-1-id"
-        ))).build()
-        val extractStatePlugin = ExtractStatePlugin()
-        val identifyMsg = IdentifyMessage.create(timestamp = RudderUtils.timeStamp,
-        traits = mapOf("userId" to "userId"));
-//        val centralPluginChain = CentralPluginChain(identifyMsg, listOf(RudderOptionPlugin(options),
-//            extractStatePlugin))
-//        centralPluginChain.proceed(identifyMsg)
+    private lateinit var plugin: ExtractStatePlugin
 
-        //TODO(add tests. currently we are not using core)
-//        assertThat(storage.traits, allOf(aMapWithSize(1),
-//        hasEntry("userId", "userId")))
-//        assertThat(storage.externalIds, iterableWithSize(1))
-//        assertThat(
-//            storage.externalIds!![0], allOf(aMapWithSize(1),
-//            hasEntry("dest-1", "dest-1-id")))
-    }
-    @Test
-    fun `test identify with both options and message external ids`(){
-        val storage = BasicStorageImpl( )
-        val options = RudderOptions.Builder().withExternalIds(listOf(mapOf(
-            "dest-1" to "dest-1-id"
-        ),mapOf(
-            "dest-2" to "dest-2-id"
-        )
-        )).build()
-        val extractStatePlugin = ExtractStatePlugin()
-        val identifyMsg = IdentifyMessage.create(timestamp = RudderUtils.timeStamp,
-        traits = mapOf("userId" to "userId"), externalIds = listOf(mapOf(
-                "dest-3" to "dest-3-id"
-            ), mapOf(
-                "dest-2" to "not-dest-2-id"
-            ) ))
-//        val centralPluginChain = CentralPluginChain(identifyMsg, listOf(RudderOptionPlugin(options),
-//            extractStatePlugin))
-//        centralPluginChain.proceed(identifyMsg)
-//        assertThat(storage.traits, allOf(aMapWithSize(1),
-//        hasEntry("userId", "userId")))
-//        assertThat(storage.externalIds, allOf(iterableWithSize(3),
-//        everyItem(
-//            aMapWithSize(1)
-//        ), containsInAnyOrder(
-//                mapOf(
-//                    "dest-1" to "dest-1-id"
-//                ),mapOf(
-//                    "dest-2" to "not-dest-2-id"
-//                ),
-//                mapOf(
-//                    "dest-3" to "dest-3-id"
-//                )
-//        )
-//        ))
-    }
-    @Test
-    fun `test identify with message external ids`(){
-        val storage = BasicStorageImpl( )
-        val options = RudderOptions.defaultOptions()
-        val extractStatePlugin = ExtractStatePlugin(
-        )
-        val identifyMsg = IdentifyMessage.create(timestamp = RudderUtils.timeStamp,
-        traits = mapOf("userId" to "userId"), externalIds = listOf(mapOf(
-                "dest-1" to "dest-1-id"
-            )))
-//        val centralPluginChain = CentralPluginChain(identifyMsg, listOf(RudderOptionPlugin(options),
-//            extractStatePlugin))
-//        centralPluginChain.proceed(identifyMsg)
+    private lateinit var analytics: Analytics
 
-//        assertThat(storage.traits, allOf(aMapWithSize(1),
-//        hasEntry("userId", "userId")))
-//        assertThat(storage.externalIds, iterableWithSize(1))
-//        assertThat(
-//            storage.externalIds!![0], allOf(aMapWithSize(1),
-//            hasEntry("dest-1", "dest-1-id")))
+    @Mock
+    private lateinit var chain: Plugin.Chain
+
+//    private var context: MessageContext = mapOf()
+
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this);
+        analytics = generateTestAnalytics(ConfigurationAndroid(ApplicationProvider.getApplicationContext(),
+            mock<JsonAdapter>(),
+            anonymousId = "anonymousId",
+            shouldVerifySdk = false),
+            storage = mock<AndroidStorage>())
+        plugin = ExtractStatePlugin()
+        plugin.setup(analytics)
     }
+    @After
+    fun destroy(){
+        plugin.onShutDown()
+        analytics.shutdown()
+    }
+
+    @Test
+    fun `intercept should proceed if message is not IdentifyMessage or AliasMessage`() {
+        val message = TrackMessage.create("ev", RudderUtils.timeStamp)
+        `when`(chain.message()).thenReturn(message)
+        plugin.intercept(chain)
+        verify(chain).proceed(message)
+    }
+
+    @Test
+    fun `intercept should proceed with modified message for IdentifyMessage with anonymousId`() {
+        val identifyMessage = IdentifyMessage.create(traits = mapOf("anonymousId" to null, "userId" to "userId"), timestamp = RudderUtils.timeStamp)
+        `when`(chain.message()).thenReturn(identifyMessage)
+
+        plugin.intercept(chain)
+        val messageCaptor = argumentCaptor<IdentifyMessage>()
+        verify(chain).proceed(messageCaptor.capture())
+        println("118,${messageCaptor.allValues}")
+        val capturedMessage = messageCaptor.lastValue
+        MatcherAssert.assertThat(capturedMessage.context?.traits?.get("anonymousId"), Matchers.notNullValue())
+    }
+
+    @Test
+    fun `intercept should update context with new userId for AliasMessage`() {
+        val aliasMessage = AliasMessage.create(RudderUtils.timeStamp, userId = "newUserId")
+        `when`(chain.message()).thenReturn(aliasMessage)
+        plugin.intercept(chain)
+        val messageCaptor = argumentCaptor<AliasMessage>()
+
+        verify(chain).proceed(messageCaptor.capture())
+        val capturedMessage = messageCaptor.lastValue
+        assertEquals("newUserId", capturedMessage.userId)
+    }
+
+ /*   @Test
+    fun `getUserId should return userId from context`() {
+        `when`(message.context).thenReturn(context)
+        `when`(context["user_id"]).thenReturn("userId")
+
+        val userId = plugin.getUserId(message)
+        assertEquals("userId", userId)
+    }
+
+    @Test
+    fun `getUserId should return userId from context traits`() {
+        `when`(message.context).thenReturn(context)
+        `when`(context.traits).thenReturn(mapOf("user_id" to "userId"))
+
+        val userId = plugin.getUserId(message)
+        assertEquals("userId", userId)
+    }
+
+    @Test
+    fun `getUserId should return userId from message`() {
+        `when`(message.context).thenReturn(null)
+        `when`(message.userId).thenReturn("userId")
+
+        val userId = plugin.getUserId(message)
+        assertEquals("userId", userId)
+    }
+
+    @Test
+    fun `appendContext should merge context`() {
+        val contextState = mock(ContextState::class.java)
+        `when`(analytics.contextState).thenReturn(contextState)
+        `when`(contextState.value).thenReturn(context)
+        val newContext = mock(MessageContext::class.java)
+        `when`(context optAddContext context).thenReturn(newContext)
+
+        plugin.appendContext(context)
+
+        verify(analytics).processNewContext(newContext)
+    }
+
+    @Test
+    fun `replaceContext should replace context`() {
+        plugin.replaceContext(context)
+
+        verify(analytics).processNewContext(context)
+    }
+
+    @Test
+    fun `updateNewAndPrevUserIdInContext should update context with new userId`() {
+        val newContext = mock(MessageContext::class.java)
+        `when`(context.updateWith(any())).thenReturn(newContext)
+
+        val updatedContext = plugin.updateNewAndPrevUserIdInContext("newUserId", context)
+
+        assertEquals(newContext, updatedContext)
+    }
+*/
+   /* @Test
+    fun `intercept should handle IdentifyMessage with same userId`() {
+        val identifyMessage = mock(IdentifyMessage::class.java)
+        `when`(identifyMessage.context).thenReturn(context)
+        `when`(context.traits).thenReturn(mapOf("userId" to "userId"))
+        `when`(analytics.currentConfigurationAndroid?.userId).thenReturn("userId")
+        `when`(chain.message()).thenReturn(identifyMessage)
+        `when`(context.updateWith(any())).thenReturn(context)
+
+        plugin.intercept(chain)
+
+        verify(chain).proceed(identifyMessage)
+    }
+
+    @Test
+    fun `intercept should handle IdentifyMessage with different userId`() {
+        val identifyMessage = mock(IdentifyMessage::class.java)
+        `when`(identifyMessage.context).thenReturn(context)
+        `when`(context.traits).thenReturn(mapOf("userId" to "newUserId"))
+        `when`(analytics.currentConfigurationAndroid?.userId).thenReturn("oldUserId")
+        `when`(chain.message()).thenReturn(identifyMessage)
+        `when`(context.updateWith(any())).thenReturn(context)
+
+        plugin.intercept(chain)
+
+        verify(chain).proceed(messageCaptor.capture())
+        val capturedMessage = messageCaptor.value as IdentifyMessage
+        assertEquals("newUserId", capturedMessage.userId)
+    }*/
 }

--- a/android/src/test/java/com/rudderstack/android/plugins/ExtractStatePluginTest.kt
+++ b/android/src/test/java/com/rudderstack/android/plugins/ExtractStatePluginTest.kt
@@ -54,7 +54,6 @@ class ExtractStatePluginTest {
     @Mock
     private lateinit var chain: Plugin.Chain
 
-//    private var context: MessageContext = mapOf()
 
 
     @Before
@@ -90,7 +89,6 @@ class ExtractStatePluginTest {
         plugin.intercept(chain)
         val messageCaptor = argumentCaptor<IdentifyMessage>()
         verify(chain).proceed(messageCaptor.capture())
-        println("118,${messageCaptor.allValues}")
         val capturedMessage = messageCaptor.lastValue
         MatcherAssert.assertThat(capturedMessage.context?.traits?.get("anonymousId"), Matchers.notNullValue())
     }

--- a/android/src/test/java/com/rudderstack/android/plugins/FillDefaultsPluginTest.kt
+++ b/android/src/test/java/com/rudderstack/android/plugins/FillDefaultsPluginTest.kt
@@ -126,18 +126,9 @@ class FillDefaultsPluginTest {
                     hasEntry("custom_name", "c_name"),
                 )
             )
+            // track messages shouldn't contain external ids
             assertThat(
-                output?.context?.externalIds, allOf(
-                    notNullValue(), iterableWithSize(2), everyItem(
-                        aMapWithSize(1)
-                    ), containsInAnyOrder(
-                        mapOf(
-                            "amp_id" to "amp_id"
-                        ), mapOf(
-                            "some_id" to "s_id"
-                        )
-                    )
-                )
+                output?.context?.externalIds, anyOf(nullValue(), emptyIterable<Map<String,String>>())
             )
         })
 

--- a/android/src/test/java/com/rudderstack/android/plugins/FillDefaultsPluginTest.kt
+++ b/android/src/test/java/com/rudderstack/android/plugins/FillDefaultsPluginTest.kt
@@ -105,7 +105,7 @@ class FillDefaultsPluginTest {
 //        val chain = CentralPluginChain(message, listOf(fillDefaultsPlugin))
         analytics.testPlugin(fillDefaultsPlugin)
         analytics.track(message)
-        analytics.assertArgument(Verification<Message?, Message?> { input, output ->
+        analytics.assertArgument { input, output ->
             //check for expected values
             assertThat(output?.anonymousId, allOf(notNullValue(), `is`("anon_id")))
             assertThat(output?.userId, allOf(notNullValue(), `is`("user_id")))
@@ -126,11 +126,15 @@ class FillDefaultsPluginTest {
                     hasEntry("custom_name", "c_name"),
                 )
             )
-            // track messages shouldn't contain external ids
+            // track messages shouldn't contain external ids sent inside it.
+            // but it should have the context values
             assertThat(
-                output?.context?.externalIds, anyOf(nullValue(), emptyIterable<Map<String,String>>())
+                output?.context?.externalIds,
+                containsInAnyOrder(mapOf("braze_id" to "b_id"),
+                    mapOf("amp_id" to "a_id"))
+
             )
-        })
+        }
 
     }
 }

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -65,11 +65,8 @@ class Analytics private constructor(
                 writeKey
             ), initializationListener, shutdownHook
 
-        ).also {
-            print("delegate created $it")
-        }
-    ){
-        println(" for analytics $this")}
+        )
+    ){}
 
 
     companion object {
@@ -92,28 +89,24 @@ class Analytics private constructor(
      * @param message
      * @param options
      */
-    fun track(message: TrackMessage, options: RudderOptions? = null) {
+    fun track(message: TrackMessage, options: RudderOption? = null) {
         processMessage(message, options)
     }
 
     @JvmOverloads
     fun track(
         eventName: String,
-        options: RudderOptions? = null,
+        options: RudderOption? = null,
         userId: String? = null,
         anonymousId: String? = null,
         trackProperties: TrackProperties? = null,
         traits: Map<String, Any?>? = null,
-        externalIds: List<Map<String, String>>? = null,
-        customContextMap: Map<String, Any>? = null,
         destinationProps: MessageDestinationProps? = null,
     ) {
         track(
             TrackMessage.create(
                 anonymousId = anonymousId,
                 traits = traits,
-                externalIds = externalIds,
-                customContextMap = customContextMap,
                 destinationProps = destinationProps,
                 timestamp = RudderUtils.timeStamp,
                 eventName = eventName,
@@ -162,7 +155,7 @@ class Analytics private constructor(
         track(trackScope.message, trackScope.options)
     }
 
-    fun screen(message: ScreenMessage, options: RudderOptions? = null) {
+    fun screen(message: ScreenMessage, options: RudderOption? = null) {
         processMessage(message, options)
     }
 
@@ -170,22 +163,18 @@ class Analytics private constructor(
     fun screen(
         screenName: String,
         category: String? = null,
-        options: RudderOptions? = null,
+        options: RudderOption? = null,
         screenProperties: ScreenProperties,
         anonymousId: String? = null,
         userId: String? = null,
         destinationProps: MessageDestinationProps? = null,
         traits: Map<String, Any?>? = null,
-        externalIds: List<Map<String, String>>? = null,
-        customContextMap: Map<String, Any>? = null,
     ) {
         screen(
             ScreenMessage.create(
                 userId = userId,
                 anonymousId = anonymousId,
                 destinationProps = destinationProps,
-                externalIds = externalIds,
-                customContextMap = customContextMap,
                 traits = traits,
                 timestamp = RudderUtils.timeStamp,
                 category = category,
@@ -201,7 +190,7 @@ class Analytics private constructor(
         screen(screenScope.message, screenScope.options)
     }
 
-    fun identify(message: IdentifyMessage, options: RudderOptions? = null) {
+    fun identify(message: IdentifyMessage, options: RudderOption? = null) {
         processMessage(message, options)
     }
 
@@ -209,11 +198,9 @@ class Analytics private constructor(
     fun identify(
         userId: String, traits: IdentifyTraits? = null,
         anonymousId: String? = null,
-        options: RudderOptions? = null,
+        options: RudderOption? = null,
         properties: IdentifyProperties? = null,
         destinationProps: MessageDestinationProps? = null,
-        externalIds: List<Map<String, String>>? = null,
-        customContextMap: Map<String, Any>? = null,
     ) {
         val completeTraits = mapOf("userId" to userId) optAdd traits
         identify(
@@ -224,8 +211,6 @@ class Analytics private constructor(
                 timestamp = RudderUtils.timeStamp,
                 traits = completeTraits,
                 properties = properties,
-                externalIds = externalIds,
-                customContextMap = customContextMap
             ), options
         )
     }
@@ -236,7 +221,7 @@ class Analytics private constructor(
         identify(identifyScope.message, identifyScope.options)
     }
 
-    fun alias(message: AliasMessage, options: RudderOptions? = null) {
+    fun alias(message: AliasMessage, options: RudderOption? = null) {
         processMessage(message, options)
     }
 
@@ -244,11 +229,9 @@ class Analytics private constructor(
     fun alias(
         newId: String,
         anonymousId: String? = null,
-        options: RudderOptions? = null,
+        options: RudderOption? = null,
         destinationProps: MessageDestinationProps? = null,
         previousId: String? = null,
-        externalIds: List<Map<String, String>>? = null,
-        customContextMap: Map<String, Any>? = null,
     ) {
         val completeTraits = mapOf("userId" to newId)
         alias(
@@ -256,9 +239,6 @@ class Analytics private constructor(
                 anonymousId = anonymousId,
                 previousId=previousId,
                 destinationProps = destinationProps,
-                externalIds = externalIds,
-                customContextMap = customContextMap,
-
                 userId = newId, traits = completeTraits),
             options
         )
@@ -270,23 +250,18 @@ class Analytics private constructor(
         alias(aliasScope.message, aliasScope.options)
     }
 
-    fun group(message: GroupMessage, options: RudderOptions? = null) {
+    fun group(message: GroupMessage, options: RudderOption? = null) {
         processMessage(message, options)
     }
 
     @JvmOverloads
     fun group(
         groupId: String?,
-        options: RudderOptions? = null,
+        options: RudderOption? = null,
         userId: String? = null,
         anonymousId: String? = null,
         groupTraits: GroupTraits?,
-
         destinationProps: MessageDestinationProps? = null,
-
-        externalIds: List<Map<String, String>>? = null,
-        customContextMap: Map<String, Any>? = null,
-
     ) {
         group(
             GroupMessage.create(
@@ -296,8 +271,6 @@ class Analytics private constructor(
                 groupTraits = groupTraits,
                 anonymousId = anonymousId,
                 destinationProps = destinationProps,
-                externalIds = externalIds,
-                customContextMap = customContextMap
             ), options
         )
     }

--- a/core/src/main/java/com/rudderstack/core/Configuration.kt
+++ b/core/src/main/java/com/rudderstack/core/Configuration.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors
  *  trackLifecycleEvents = true)
  * ```
  *
- * @property options Global [RudderOptions] for all plugins
+ * @property options Global [RudderOption] for all plugins
  * @property flushQueueSize Max elements to be stored before a flush. Once it passes this threshold,
  * flush is triggered
  * @property maxFlushInterval Max time (in millis) to wait for a flush, even if the queue size hasn't
@@ -37,7 +37,7 @@ import java.util.concurrent.Executors
  */
 interface Configuration {
     val jsonAdapter: JsonAdapter
-    val options: RudderOptions
+    val options: RudderOption
     val flushQueueSize: Int
     val maxFlushInterval: Long
     // changing the value post source config download has no effect
@@ -61,7 +61,7 @@ interface Configuration {
         const val MAX_FLUSH_INTERVAL = 10 * 1000L //10 seconds
         operator fun invoke(
             jsonAdapter: JsonAdapter,
-            options: RudderOptions = RudderOptions.defaultOptions(),
+            options: RudderOption = RudderOption(),
             flushQueueSize: Int = FLUSH_QUEUE_SIZE,
             maxFlushInterval: Long = MAX_FLUSH_INTERVAL,
             shouldVerifySdk: Boolean = false,
@@ -75,7 +75,7 @@ interface Configuration {
             base64Generator: Base64Generator = RudderUtils.defaultBase64Generator,
         ) = object : Configuration {
             override val jsonAdapter: JsonAdapter = jsonAdapter
-            override val options: RudderOptions = options
+            override val options: RudderOption = options
             override val flushQueueSize: Int = flushQueueSize
             override val maxFlushInterval: Long = maxFlushInterval
             override val shouldVerifySdk: Boolean = shouldVerifySdk
@@ -91,7 +91,7 @@ interface Configuration {
     }
     fun copy(
         jsonAdapter: JsonAdapter = this.jsonAdapter,
-        options: RudderOptions = this.options,
+        options: RudderOption = this.options,
         flushQueueSize: Int = this.flushQueueSize,
         maxFlushInterval: Long = this.maxFlushInterval,
         shouldVerifySdk: Boolean = this.shouldVerifySdk,

--- a/core/src/main/java/com/rudderstack/core/Controller.kt
+++ b/core/src/main/java/com/rudderstack/core/Controller.kt
@@ -101,10 +101,10 @@ interface Controller {
      * the ones in options will replace those of message.
      *
      * @param message A [Message] object up for submission
-     * @param options Individual [RudderOptions] for this message. Only applicable for this message
+     * @param options Individual [RudderOption] for this message. Only applicable for this message
      * @param lifecycleController LifeCycleController related to this message, null for default implementation
      */
-    fun processMessage(message: Message, options: RudderOptions?, lifecycleController: LifecycleController? = null)
+    fun processMessage(message: Message, options: RudderOption?, lifecycleController: LifecycleController? = null)
 
     /**
      * Add a [Callback] for getting notified when a message is processed

--- a/core/src/main/java/com/rudderstack/core/RudderOption.kt
+++ b/core/src/main/java/com/rudderstack/core/RudderOption.kt
@@ -25,60 +25,43 @@ package com.rudderstack.core
  * message will be delivered to all destinations added to Analytics.
  * @property customContexts Custom context elements that are going to be sent with message
  */
-class RudderOptions private constructor(
-    val externalIds: List<Map<String, String>>,
-    val integrations: Map<String, Boolean>,
-    val customContexts: Map<String, Any>,
+class RudderOption{
+    val integrations: Map<String, Boolean>
+        get() = _integrations
+    private val _integrations = mutableMapOf<String,Boolean>()
+    val customContexts: Map<String, Any>
+        get() = _customContexts
+    private val _customContexts = mutableMapOf<String, Any>()
 
-    ) {
-    companion object{
-        /**
-         * Default options
-         *
-         */
-        @JvmStatic
-        fun defaultOptions(): RudderOptions = RudderOptions(listOf(), mapOf(), mapOf())
+    val externalIds: List<Map<String, String>>
+        get() = _externalIds
+    private val _externalIds= mutableListOf<Map<String, String>>()
+
+    fun putExternalId(type: String, id: String): RudderOption {
+        _externalIds.add(
+            mapOf("type" to type,
+                "id" to id)
+        )
+        return this
+    }
+    fun putIntegration(destinationKey: String, enabled: Boolean): RudderOption {
+        _integrations[destinationKey] = enabled
+        return this
     }
 
-    /**
-     * Creates a new builder from this object.
-     *
-     */
-    fun newBuilder(): Builder {
-        return Builder().withExternalIds(externalIds).withIntegrations(integrations)
-            .withCustomContexts(customContexts)
+    fun putIntegration(destination: BaseDestinationPlugin<*>, enabled: Boolean): RudderOption {
+        _integrations[destination.name] = enabled
+        return this
     }
 
-    /**
-     * Builder for RudderOption
-     *
-     */
-    class Builder {
-        private var _externalIds: List<Map<String, String>> = listOf()
-        private var _integrations: Map<String, Boolean> = mapOf()
-        private var _customContexts: Map<String, Any> = mapOf()
-
-
-        fun withExternalIds(externalIds: List<Map<String, String>>): Builder {
-            this._externalIds = externalIds
-            return this
-        }
-
-        fun withIntegrations(integrations: Map<String, Boolean>): Builder {
-            this._integrations = integrations
-            return this
-        }
-
-        fun withCustomContexts(customContexts: Map<String, Any>): Builder {
-            this._customContexts = customContexts
-            return this
-        }
-
-        fun build() = RudderOptions(_externalIds, _integrations, _customContexts)
+    fun putCustomContext(key: String, context: Map<String?, Any?>): RudderOption {
+        _customContexts[key] = context
+        return this
     }
+
 
     override fun equals(other: Any?): Boolean {
-        return other is RudderOptions &&
+        return other is RudderOption &&
                 other.externalIds == this.externalIds &&
                 other.integrations == this.integrations &&
                 other.customContexts == this.customContexts

--- a/core/src/main/java/com/rudderstack/core/compat/ConfigurationBuilder.java
+++ b/core/src/main/java/com/rudderstack/core/compat/ConfigurationBuilder.java
@@ -21,7 +21,7 @@ import com.rudderstack.core.Base64Generator;
 import com.rudderstack.core.Configuration;
 import com.rudderstack.core.Logger;
 import com.rudderstack.core.RetryStrategy;
-import com.rudderstack.core.RudderOptions;
+import com.rudderstack.core.RudderOption;
 import com.rudderstack.core.RudderUtils;
 import com.rudderstack.core.internal.KotlinLogger;
 import com.rudderstack.rudderjsonadapter.JsonAdapter;
@@ -31,7 +31,7 @@ import java.util.concurrent.Executors;
 
 public class ConfigurationBuilder {
     private JsonAdapter jsonAdapter;
-    private RudderOptions options = RudderOptions.defaultOptions();
+    private RudderOption options = new RudderOption();
     private int flushQueueSize = FLUSH_QUEUE_SIZE;
     private long maxFlushInterval = MAX_FLUSH_INTERVAL;
     private boolean shouldVerifySdk = false;
@@ -48,7 +48,7 @@ public class ConfigurationBuilder {
         this.jsonAdapter = jsonAdapter;
     }
 
-    public ConfigurationBuilder withOptions(RudderOptions options) {
+    public ConfigurationBuilder withOptions(RudderOption options) {
         this.options = options;
         return this;
     }

--- a/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/AnalyticsDelegate.kt
@@ -26,7 +26,7 @@ import com.rudderstack.core.InfrastructurePlugin
 import com.rudderstack.core.LifecycleController
 import com.rudderstack.core.Logger
 import com.rudderstack.core.Plugin
-import com.rudderstack.core.RudderOptions
+import com.rudderstack.core.RudderOption
 import com.rudderstack.core.RudderUtils.getUTF8Length
 import com.rudderstack.core.RudderUtils.MAX_BATCH_SIZE
 import com.rudderstack.core.Storage
@@ -319,7 +319,7 @@ internal class AnalyticsDelegate(
 
 
     override fun processMessage(
-        message: Message, options: RudderOptions?, lifecycleController: LifecycleController?
+        message: Message, options: RudderOption?, lifecycleController: LifecycleController?
     ) {
         if (isShutdown) {
             logger.warn(log = "Analytics has shut down, ignoring message $message")
@@ -334,14 +334,14 @@ internal class AnalyticsDelegate(
         }
     }
 
-    private fun generatePluginsWithOptions(options: RudderOptions?): List<Plugin> {
+    private fun generatePluginsWithOptions(options: RudderOption?): List<Plugin> {
         return synchronized(PLUGIN_LOCK) {
             _internalPreMessagePlugins + (options ?: currentConfiguration?.options
-                                          ?: RudderOptions.defaultOptions()).createPlugin() + _customPlugins + _internalPostCustomPlugins + _destinationPlugins
+                                          ?: RudderOption()).createPlugin() + _customPlugins + _internalPostCustomPlugins + _destinationPlugins
         }.toList()
     }
 
-    private fun RudderOptions.createPlugin(): Plugin {
+    private fun RudderOption.createPlugin(): Plugin {
         return RudderOptionPlugin(
             this
         ).also {

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/RudderOptionPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/RudderOptionPlugin.kt
@@ -17,7 +17,7 @@ package com.rudderstack.core.internal.plugins
 import com.rudderstack.models.*
 import com.rudderstack.core.DestinationPlugin
 import com.rudderstack.core.Plugin
-import com.rudderstack.core.RudderOptions
+import com.rudderstack.core.RudderOption
 import com.rudderstack.core.minusWrtKeys
 
 /**
@@ -29,11 +29,11 @@ import com.rudderstack.core.minusWrtKeys
  * that integration will be dumped and not used.
  * Likewise if "All" is set to false but a particular integration is set to true, we use it.
  *
- * In case of [MessageContext] values of [Message.context] and [RudderOptions] are merged together.
+ * In case of [MessageContext] values of [Message.context] and [RudderOption] are merged together.
  *
  * @param options
  */
-internal class RudderOptionPlugin(private val options: RudderOptions) : Plugin {
+internal class RudderOptionPlugin(private val options: RudderOption) : Plugin {
 
     override fun intercept(chain: Plugin.Chain): Message {
         val msg = chain.message().let { oldMsg ->
@@ -78,7 +78,7 @@ internal class RudderOptionPlugin(private val options: RudderOptions) : Plugin {
 
     }
 
-    private fun Message.updateContext(options: RudderOptions): MessageContext? {
+    private fun Message.updateContext(options: RudderOption): MessageContext? {
         //external ids can be present in both message or options.
         //save concatenated external ids, if present with both message and options
         val messageExternalIds = context?.externalIds

--- a/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
+++ b/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
@@ -73,21 +73,23 @@ abstract class AnalyticsTest {
             ),
         )
     )
-    private lateinit var mockedControlPlane : ConfigDownloadService
-    private lateinit var mockedDataUploadService : DataUploadService
+    private lateinit var mockedControlPlane: ConfigDownloadService
+    private lateinit var mockedDataUploadService: DataUploadService
 
     @Before
     fun setup() {
         mockedControlPlane = mock(ConfigDownloadService::class.java).also {
             `when`(it.download(any())).then {
 
-                it.getArgument<(success: Boolean, RudderServerConfig?, lastErrorMsg: String?) -> Unit>(0)
+                it.getArgument<(success: Boolean, RudderServerConfig?, lastErrorMsg: String?) -> Unit>(
+                    0
+                )
                     .invoke(
                         true, mockServerConfig, null
                     )
             }
         }
-        mockedDataUploadService = mock (com.rudderstack.core.DataUploadService::class.java)
+        mockedDataUploadService = mock(com.rudderstack.core.DataUploadService::class.java)
         storage = BasicStorageImpl()
         val mockedResponse: HttpResponse<out Any> = HttpResponse(200, "OK", null)
         mockedDataUploadService.let {
@@ -165,7 +167,7 @@ abstract class AnalyticsTest {
                 assertThat(success, `is`(false))
                 assertThat(message, `is`("Downloading failed, Shutting down some error"))
             }, configDownloadService = mockedControlPlane,
-            shutdownHook = {  isDone.set(true) }
+            shutdownHook = { isDone.set(true) }
         )
 
 
@@ -183,6 +185,7 @@ abstract class AnalyticsTest {
             any()
         )
     }
+
     @Test
     fun `test configuration has proper retry strategy`() {
         println("running test test configuration has proper retry strategy")
@@ -330,7 +333,6 @@ abstract class AnalyticsTest {
 
     @Test
     fun `test with rudder option`() {
-        println("running test test with rudder option")
         //given
         analytics.shutdown()
         analytics = Analytics(
@@ -345,11 +347,13 @@ abstract class AnalyticsTest {
             dataUploadService = mockedDataUploadService,
             configDownloadService = mockedControlPlane
         )
-        while(analytics.retrieveState<DestinationConfigState>()?.value == null){}
+        while (analytics.retrieveState<DestinationConfigState>()?.value == null) {
+        }
         busyWait(300L) // enough for server config to be downloaded
-        val rudderOptions = RudderOptions.Builder().withExternalIds(
-            listOf(mapOf("some_id" to "id"))
-        ).withIntegrations(mapOf("enabled-destination" to true, "All" to false)).build()
+        val rudderOption = RudderOption().putExternalId(
+            "some_type", "some_id"
+        ).putIntegration("enabled-destination", true)
+            .putIntegration("All", false)
 
         val dummyPlugin = mock(BaseDestinationPlugin::class.java)
         whenever(dummyPlugin.name).thenReturn("dummy")
@@ -360,11 +364,14 @@ abstract class AnalyticsTest {
         analytics.addPlugin(assertdestination, dummyPlugin)
 
         //when
-        val trackMessage = TrackMessage.create(eventName = "some", timestamp = RudderUtils.timeStamp)
-        analytics.track(trackMessage, options =
-        rudderOptions)
+        val trackMessage =
+            TrackMessage.create(eventName = "some", timestamp = RudderUtils.timeStamp)
+        analytics.track(
+            trackMessage, options =
+            rudderOption
+        )
         val waitUntil = AtomicBoolean(false)
-        analytics.addCallback(object : Callback{
+        analytics.addCallback(object : Callback {
             override fun success(message: Message?) {
                 waitUntil.set(message is TrackMessage && message.eventName == "some")
             }
@@ -373,7 +380,8 @@ abstract class AnalyticsTest {
                 waitUntil.set(message is TrackMessage && message.eventName == "some")
             }
         })
-        while(waitUntil.get().not()){}
+        while (waitUntil.get().not()) {
+        }
         busyWait(500L)
 
         //then
@@ -390,7 +398,14 @@ abstract class AnalyticsTest {
         )
         assertThat(
             msg.context?.externalIds, allOf(
-                notNullValue(), iterableWithSize(1), containsInAnyOrder(mapOf("some_id" to "id"))
+                notNullValue(), iterableWithSize(1), containsInAnyOrder(
+                    allOf(
+                        aMapWithSize(2),
+                        hasEntry("id", "some_id"),
+                        hasEntry("type","some_type")
+                    )
+
+                )
             )
         )
     }
@@ -420,13 +435,15 @@ abstract class AnalyticsTest {
                 flushQueueSize = 3
             )
         }
-        while(storage.getDataSync().isNotEmpty()){}
+        while (storage.getDataSync().isNotEmpty()) {
+        }
         busyWait(300)
         val listCaptor = argumentCaptor<List<Message>>()
         verify(mockedDataUploadService, atLeast(1)).uploadSync(listCaptor.capture(), anyOrNull())
         val allMsgsUploaded = listCaptor.allValues.flatten()
         assertThat(allMsgsUploaded, allOf(notNullValue(), iterableWithSize(4)))
     }
+
     @Test
     fun `test messages flushed when sent from different threads based on periodic timeout`() {
         println("running test test messages flushed when sent from different threads based on periodic timeout")
@@ -462,8 +479,8 @@ abstract class AnalyticsTest {
         }
         assertThat(analytics.currentConfiguration?.maxFlushInterval, `is`(100))
         val timeNow = System.currentTimeMillis()
-        while(storage.getDataSync().isNotEmpty()){
-            if(System.currentTimeMillis() - timeNow > 10000) break
+        while (storage.getDataSync().isNotEmpty()) {
+            if (System.currentTimeMillis() - timeNow > 10000) break
         }
         busyWait(200) // enough time for one flush
         val listCaptor = argumentCaptor<List<Message>>()
@@ -523,6 +540,7 @@ abstract class AnalyticsTest {
         verify(mockedDataUploadService, never()).uploadSync(anyList(), anyOrNull())
 //        assertThat(storage.getDataSync(), anyOf(nullValue(), iterableWithSize(0)))
     }
+
     @Test
     fun `test blocking flush`() {
         println("running test test blocking flush")
@@ -569,7 +587,8 @@ abstract class AnalyticsTest {
         for (i in events) {
             analytics.track(i)
         }
-        while ((analytics.storage.getDataSync().size) < totalMessages) {}
+        while ((analytics.storage.getDataSync().size) < totalMessages) {
+        }
 
         analytics.blockingFlush()
 
@@ -739,7 +758,7 @@ abstract class AnalyticsTest {
             it.proceed(it.message())
         }
         val waitUntil = AtomicBoolean(false)
-        analytics.addCallback(object : Callback{
+        analytics.addCallback(object : Callback {
             override fun success(message: Message?) {
                 analytics.removeCallback(this)
                 waitUntil.set(message is TrackMessage && message.eventName == "event")
@@ -763,23 +782,20 @@ abstract class AnalyticsTest {
             }
             userId("user_id")
             rudderOptions {
-                customContexts {
-                    +("cc1" to "cp1")
-                    +("cc2" to "cp2")
-                }
-                externalIds {
-                    +(mapOf("ext-1" to "ex1"))
-                    +(mapOf("ext-2" to "ex2"))
-                    +listOf(mapOf("ext-3" to "ex3"))
-                }
-                integrations {
-                    +("firebase" to true)
-                    +("amplitude" to false)
-                }
+                customContexts("cc1", mapOf("cc_1_1" to "ccv"))
+                customContexts("cc2", mapOf("cc_2_1" to "ccv2"))
+
+                externalId("ext-1", "ex1")
+                externalId("ext-2", "ex2")
+                externalId("ext-3", "ex3")
+
+                integration("firebase", true)
+                integration("amplitude", false)
+
             }
         }
         val timeStarted = System.currentTimeMillis()
-        while(waitUntil.get().not() && !isDone.get()){
+        while (waitUntil.get().not() && !isDone.get()) {
             if (System.currentTimeMillis() - timeStarted > 10000) {
                 assert(false)
                 break
@@ -878,7 +894,9 @@ abstract class AnalyticsTest {
      */
     private fun calculateNumberOfBatches(message: Message?, totalNumberOfMessages: Int): Int {
         val messageJSON = message?.let {
-            analytics.currentConfiguration?.jsonAdapter?.writeToJson(it, object : RudderTypeAdapter<Message>() {})
+            analytics.currentConfiguration?.jsonAdapter?.writeToJson(
+                it,
+                object : RudderTypeAdapter<Message>() {})
         } ?: return 0
 
         val individualMessageSize = messageJSON.getUTF8Length()

--- a/core/src/test/java/com/rudderstack/core/compat/ConfigurationBuilderTest.java
+++ b/core/src/test/java/com/rudderstack/core/compat/ConfigurationBuilderTest.java
@@ -25,7 +25,7 @@ import com.rudderstack.core.Base64Generator;
 import com.rudderstack.core.Configuration;
 import com.rudderstack.core.Logger;
 import com.rudderstack.core.RetryStrategy;
-import com.rudderstack.core.RudderOptions;
+import com.rudderstack.core.RudderOption;
 import com.rudderstack.core.Storage;
 import com.rudderstack.rudderjsonadapter.JsonAdapter;
 
@@ -46,7 +46,7 @@ public class ConfigurationBuilderTest {
 
         assertNotNull(configuration);
         assertEquals(mockJsonAdapter, configuration.getJsonAdapter());
-        assertEquals(RudderOptions.defaultOptions(), configuration.getOptions());
+        assertEquals(new RudderOption(), configuration.getOptions());
         assertEquals(Configuration.FLUSH_QUEUE_SIZE, configuration.getFlushQueueSize());
         assertEquals(Configuration.MAX_FLUSH_INTERVAL, configuration.getMaxFlushInterval());
         assertFalse(configuration.getShouldVerifySdk());
@@ -62,7 +62,7 @@ public class ConfigurationBuilderTest {
     @Test
     public void buildConfigurationWithCustomValues() {
         JsonAdapter mockJsonAdapter = mock(JsonAdapter.class);
-        RudderOptions customOptions = new RudderOptions.Builder().build();
+        RudderOption customOptions = new RudderOption();
         int customFlushQueueSize = 100;
         long customMaxFlushInterval = 5000;
         boolean customShouldVerifySdk = true;

--- a/core/src/test/java/com/rudderstack/core/internal/plugins/RudderOptionPluginTest.kt
+++ b/core/src/test/java/com/rudderstack/core/internal/plugins/RudderOptionPluginTest.kt
@@ -59,7 +59,7 @@ class RudderOptionPluginTest {
             return@Plugin it.proceed(it.message())
         }
         val chain = CentralPluginChain(message, listOf(
-            RudderOptionPlugin(RudderOptions.defaultOptions()),assertPlugin, dest1, dest2, dest3
+            RudderOptionPlugin(RudderOption()),assertPlugin, dest1, dest2, dest3
         ), originalMessage = message)
         chain.proceed(message)
     }
@@ -76,9 +76,9 @@ class RudderOptionPluginTest {
             return@Plugin it.proceed(it.message())
         }
         val chain = CentralPluginChain(message, listOf(
-            RudderOptionPlugin(RudderOptions.Builder()
-                .withIntegrations(mapOf("All" to false))
-                .build()),assertPlugin, dest1, dest2, dest3
+            RudderOptionPlugin(RudderOption()
+                .putIntegration("All", false)
+                ),assertPlugin, dest1, dest2, dest3
         ), originalMessage = message)
         chain.proceed(message)
     }
@@ -96,9 +96,10 @@ class RudderOptionPluginTest {
             return@Plugin it.proceed(it.message())
         }
         val chain = CentralPluginChain(message, listOf(
-            RudderOptionPlugin(RudderOptions.Builder()
-                .withIntegrations(mapOf("dest-2" to false,"dest-3" to false))
-                .build()),assertPlugin, dest1, dest2, dest3
+            RudderOptionPlugin(RudderOption()
+                .putIntegration("dest-2",false)
+                .putIntegration("dest-3", false))
+            ,assertPlugin, dest1, dest2, dest3
         ), originalMessage = message)
         chain.proceed(message)
     }
@@ -116,9 +117,11 @@ class RudderOptionPluginTest {
             return@Plugin it.proceed(it.message())
         }
         val chain = CentralPluginChain(message, listOf(
-            RudderOptionPlugin(RudderOptions.Builder()
-                .withIntegrations(mapOf("All" to false, "dest-2" to true,"dest-3" to false))
-                .build()),assertPlugin, dest1, dest2, dest3
+            RudderOptionPlugin(RudderOption()
+                .putIntegration("All", false)
+                .putIntegration( "dest-2", true)
+                .putIntegration("dest-3",false))
+                ,assertPlugin, dest1, dest2, dest3
         ), originalMessage = message)
         chain.proceed(message)
     }

--- a/models/src/main/java/com/rudderstack/models/Extensions.kt
+++ b/models/src/main/java/com/rudderstack/models/Extensions.kt
@@ -32,8 +32,6 @@ val MessageContext.externalIds: List<Map<String, String>>?
  */
 val MessageContext.customContexts: Map<String, Any>?
     get() = get(Constants.CUSTOM_CONTEXT_MAP_ID) as? Map<String, Any>?
-//val MessageContext.contextAddOns
-//    get() =
 fun MessageContext.withExternalIdsRemoved() = this - Constants.EXTERNAL_ID
 
 /**

--- a/models/src/main/java/com/rudderstack/models/Extensions.kt
+++ b/models/src/main/java/com/rudderstack/models/Extensions.kt
@@ -32,5 +32,68 @@ val MessageContext.externalIds: List<Map<String, String>>?
  */
 val MessageContext.customContexts: Map<String, Any>?
     get() = get(Constants.CUSTOM_CONTEXT_MAP_ID) as? Map<String, Any>?
-
+//val MessageContext.contextAddOns
+//    get() =
 fun MessageContext.withExternalIdsRemoved() = this - Constants.EXTERNAL_ID
+
+/**
+ * Priority is given to this context and not to the operand.
+ * FOr eg, if the calling context and operand both have same keys in their traits,
+ * the value assigned to the key is of the calling context one.
+ *
+ * @param context
+ * @return
+ */
+infix fun MessageContext?.optAddContext (context: MessageContext?): MessageContext? {
+    //this gets priority
+    if (this == null) return context
+    else if (context == null) return this
+    val newTraits = context.traits?.let {
+        (it - (this.traits?.keys ?: setOf()).toSet()) optAdd this.traits
+    } ?: traits
+    val newCustomContexts = context.customContexts?.let {
+        (it - (this.customContexts?.keys ?: setOf()).toSet()) optAdd this.customContexts
+    } ?: customContexts
+    val newExternalIds = context.externalIds?.let {
+        it + (this.externalIds?: emptyList())
+    } ?: externalIds
+
+    createContext(newTraits, newExternalIds, newCustomContexts).let {
+        //add the extra info from both contexts
+        val extraOperandContext = context - it.keys
+        val extraThisContext = this - it.keys
+        return it  + extraOperandContext + extraThisContext
+    }
+
+}
+private infix fun <K, V> Iterable<Map<K, V>>.minusWrtKeys(
+    operand:
+    Iterable<Map<K, V>>
+): List<Map<K, V>> {
+    operand.toSet().let { op ->
+        return this.filterNot {
+            op inWrtKeys it
+        }
+    }
+}
+
+/**
+ * infix function to match "in" condition for a map inside a list of maps based on just keys.
+ * ```
+ *  val list = listOf(
+ *  mapOf("1" to 1),
+ *  mapOf("2" to 3),
+ *  mapOf("4" to 4)
+ *  )
+ *  list inWrtKeys mapOf("2", "2") //returns true
+ * ```
+ * @param item The item to be checked
+ * @return true if the map with same keys are present, false otherwise
+ */
+infix fun <K, V> Iterable<Map<K, V>>.inWrtKeys(item: Map<K, V>): Boolean {
+    this.toSet().forEach {
+        if (it.keys.containsAll(item.keys))
+            return true
+    }
+    return false
+}

--- a/models/src/main/java/com/rudderstack/models/Extensions.kt
+++ b/models/src/main/java/com/rudderstack/models/Extensions.kt
@@ -32,3 +32,5 @@ val MessageContext.externalIds: List<Map<String, String>>?
  */
 val MessageContext.customContexts: Map<String, Any>?
     get() = get(Constants.CUSTOM_CONTEXT_MAP_ID) as? Map<String, Any>?
+
+fun MessageContext.withExternalIdsRemoved() = this - Constants.EXTERNAL_ID

--- a/models/src/main/java/com/rudderstack/models/Utils.kt
+++ b/models/src/main/java/com/rudderstack/models/Utils.kt
@@ -45,7 +45,7 @@ fun createContext(
  * @return updated context
  */
 fun MessageContext.updateWith(newContext: MessageContext): MessageContext {
-    return this optAdd newContext.filterValues { it != null  }
+    return (this optAdd newContext.filterValues { it != null }) ?: mapOf()
 }
 
 fun MessageContext.updateWith(
@@ -54,19 +54,19 @@ fun MessageContext.updateWith(
     customContextMap: Map<String, Any?>? = null,
     contextAddOns: Map<String, Any?>? = null,
 ): MessageContext {
-    return this optAdd
+    return (this optAdd
         traits?.let { (Constants.TRAITS_ID to it) } optAdd
         externalIds?.let { (Constants.EXTERNAL_ID to it) } optAdd
         customContextMap?.let { (Constants.CUSTOM_CONTEXT_MAP_ID to it) } optAdd
-        contextAddOns
+        contextAddOns)?: mapOf()
 }
 
-private infix fun<K, V> Map<K, V>.optAdd(pair: Pair<K, V>?): Map<K, V> {
+internal infix fun<K, V> Map<K, V>.optAdd(pair: Pair<K, V>?): Map<K, V> {
     return pair?.let {
         this + it
     } ?: this
 }
-private infix fun<K, V> Map<K, V>.optAdd(map: Map<K, V>?): Map<K, V> {
+internal infix fun<K, V> Map<K, V>.optAdd(map: Map<K, V>?): Map<K, V> {
     return map?.let {
         this + it
     } ?: this

--- a/models/src/test/java/com/rudderstack/models/MessageUtilsTest.kt
+++ b/models/src/test/java/com/rudderstack/models/MessageUtilsTest.kt
@@ -1,0 +1,104 @@
+package com.rudderstack.models
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.hasItems
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MessageUtilsTest{
+    @Test
+    fun `optAdd with both contexts null`() {
+        val context1: MessageContext? = null
+        val context2: MessageContext? = null
+
+        val result = context1 optAddContext  context2
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `optAdd with first context null`() {
+        val context1: MessageContext? = null
+        val context2: MessageContext = mapOf("key" to "value")
+
+        val result = context1 optAddContext  context2
+
+        assertEquals(context2, result)
+    }
+    @Test
+    fun `optAdd with second context null`() {
+        val context1: MessageContext = mapOf("key" to "value")
+        val context2: MessageContext? = null
+
+        val result = context1 optAdd context2
+
+        assertEquals(context1, result)
+    }
+
+    @Test
+    fun `optAdd with overlapping traits`() {
+        val context1: MessageContext = createContext(
+            mapOf("trait1" to "value1", "common" to "value1")
+        )
+        val context2: MessageContext = createContext(
+            mapOf("trait2" to "value2", "common" to "value2")
+        )
+        val result = context1 optAddContext  context2
+        println(result)
+        assertThat(result?.traits, allOf(
+            hasEntry("trait1",  "value1"),
+            hasEntry("trait2",  "value2"),
+            hasEntry("common",  "value1"),
+        ))
+    }
+
+    @Test
+    fun `optAdd with non-overlapping customContexts`() {
+        val context1: MessageContext = mapOf(
+            Constants.CUSTOM_CONTEXT_MAP_ID to mapOf("context1" to "value1")
+        )
+        val context2: MessageContext = mapOf(
+            Constants.CUSTOM_CONTEXT_MAP_ID to mapOf("context2" to "value2")
+        )
+
+        val result = context1 optAddContext  context2
+
+        assertThat(result?.customContexts, allOf(
+            hasEntry("context1", "value1"),
+            hasEntry("context2", "value2"),
+        ))
+    }
+
+    @Test
+    fun `optAdd with overlapping externalIds`() {
+        val context1: MessageContext = createContext(
+            externalIds =  listOf(mapOf("id1" to "value1"))
+        )
+        val context2: MessageContext = createContext(
+            externalIds =  listOf(mapOf("id2" to "value2"), mapOf("id1" to "value3"))
+        )
+
+        val result = context1 optAddContext  context2
+
+        assertThat(result?.externalIds, hasItems(mapOf("id1" to "value1"), mapOf("id2" to "value2"), mapOf("id2" to "value2")))
+    }
+
+    @Test
+    fun `optAdd with extra keys`() {
+        val context1: MessageContext = mapOf("extra1" to "value1", "common" to "value1")
+        val context2: MessageContext = mapOf("extra2" to "value2", "common" to "value2")
+
+        val result = context1 optAddContext  context2
+
+        assertThat(result, allOf(
+            hasEntry("extra1", "value1"),
+            hasEntry("extra2", "value2"),
+            hasEntry("common", "value1"),
+        ))
+    }
+}

--- a/samples/sample-kotlin-android/build.gradle.kts
+++ b/samples/sample-kotlin-android/build.gradle.kts
@@ -124,6 +124,8 @@ dependencies {
     implementation("androidx.compose.runtime:runtime-livedata:1.4.3")
     implementation("androidx.compose.ui:ui-tooling-preview:1.4.3")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    // adding play services to generate advertising id
+    implementation("com.google.android.gms:play-services-ads:22.1.0")
 
     implementation(project(":android"))
     implementation(project(":moshirudderadapter"))

--- a/samples/sample-kotlin-android/src/main/AndroidManifest.xml
+++ b/samples/sample-kotlin-android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <application
         android:name=".MyApplication"
         android:allowBackup="true"
@@ -22,6 +23,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-4271859468376006~9737595580" />
+
     </application>
 
 </manifest>

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -10,6 +10,7 @@ import com.rudderstack.android.ruddermetricsreporterandroid.LibraryMetadata
 import com.rudderstack.android.ruddermetricsreporterandroid.RudderReporter
 import com.rudderstack.android.sampleapp.analytics.workmanger.SampleWorkManagerPlugin
 import com.rudderstack.core.Analytics
+import com.rudderstack.core.RudderOptions
 import com.rudderstack.gsonrudderadapter.GsonAdapter
 import com.rudderstack.jacksonrudderadapter.JacksonAdapter
 
@@ -34,6 +35,8 @@ object RudderAnalyticsUtils {
             configuration = ConfigurationAndroid(
                 application = application,
                 GsonAdapter(),
+                options = RudderOptions.Builder()
+                    .withExternalIds(listOf(mapOf("key_ext" to "val_ext"))).build(),
                 dataPlaneUrl = DATA_PLANE_URL,
                 controlPlaneUrl = CONTROL_PLANE_URL,
                 trackLifecycleEvents = true,

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -34,8 +34,6 @@ object RudderAnalyticsUtils {
             configuration = ConfigurationAndroid(
                 application = application,
                 GsonAdapter(),
-//                options = RudderOptions.Builder()
-//                    .withExternalIds(listOf(mapOf("key_ext" to "val_ext"))).build(),
                 dataPlaneUrl = DATA_PLANE_URL,
                 controlPlaneUrl = CONTROL_PLANE_URL,
                 trackLifecycleEvents = true,

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -38,7 +38,8 @@ object RudderAnalyticsUtils {
                 controlPlaneUrl = CONTROL_PLANE_URL,
                 trackLifecycleEvents = true,
                 recordScreenViews = true,
-                isPeriodicFlushEnabled = true
+                isPeriodicFlushEnabled = true,
+                autoCollectAdvertId = true
             )
         )
         _rudderReporter = DefaultRudderReporter(

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -10,7 +10,6 @@ import com.rudderstack.android.ruddermetricsreporterandroid.LibraryMetadata
 import com.rudderstack.android.ruddermetricsreporterandroid.RudderReporter
 import com.rudderstack.android.sampleapp.analytics.workmanger.SampleWorkManagerPlugin
 import com.rudderstack.core.Analytics
-import com.rudderstack.core.RudderOptions
 import com.rudderstack.gsonrudderadapter.GsonAdapter
 import com.rudderstack.jacksonrudderadapter.JacksonAdapter
 
@@ -35,8 +34,8 @@ object RudderAnalyticsUtils {
             configuration = ConfigurationAndroid(
                 application = application,
                 GsonAdapter(),
-                options = RudderOptions.Builder()
-                    .withExternalIds(listOf(mapOf("key_ext" to "val_ext"))).build(),
+//                options = RudderOptions.Builder()
+//                    .withExternalIds(listOf(mapOf("key_ext" to "val_ext"))).build(),
                 dataPlaneUrl = DATA_PLANE_URL,
                 controlPlaneUrl = CONTROL_PLANE_URL,
                 trackLifecycleEvents = true,

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/mainview/MainViewModel.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/mainview/MainViewModel.kt
@@ -9,7 +9,7 @@ import com.rudderstack.android.utilities.endSession
 import com.rudderstack.android.utilities.startSession
 import com.rudderstack.core.Analytics
 import com.rudderstack.core.Plugin
-import com.rudderstack.core.RudderOptions
+import com.rudderstack.core.RudderOption
 import com.rudderstack.models.GroupTraits
 import com.rudderstack.models.IdentifyTraits
 import com.rudderstack.models.Message
@@ -54,6 +54,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     init {
         analytics.addPlugin(_loggingInterceptor)
     }
+    private var extCount = 1
 
     internal fun onEventClicked(analytics: AnalyticsState) {
         val log = when (analytics) {
@@ -66,18 +67,21 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 RudderAnalyticsUtils.analytics.track(
                     eventName = "Track at ${Date()}",
                     trackProperties = TrackProperties("key1" to "prop1", "key2" to "prop2"),
-                    options = RudderOptions.Builder().withIntegrations(mapOf("firebase" to false))
-                        .withExternalIds(
-                            listOf(mapOf("fb_id" to "1234"))
-                        ).build()
+                    options = RudderOption().putIntegration("firebase", false)
+                        .putExternalId(
+                            "fb_id","1234"
+                        )
                 )
                 "Track message sent"
             }
 
             AnalyticsState.IdentifyEvent -> {
                 RudderAnalyticsUtils.analytics.identify(
-                    userId = "some_user_id", traits = IdentifyTraits("trait1" to "some_trait")
+                    userId = "some_user_id", traits = IdentifyTraits("trait1" to "some_trait"),
+                    options = RudderOption().putExternalId("test_ext_id_key_$extCount", "test_val_$extCount")
+
                 )
+                ++ extCount
                 "Identify called"
             }
 


### PR DESCRIPTION
**Fixes** # (*issue*)
Remove external ids from all messages except identify.
Collection of advertising Id is fixed. Previously the default executor for ad id collection was null.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
