### PR TITLE
fix: activity is now broadcasted irrespective of recordScreenView or trackLifecycle

### DIFF
--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/ActivityBroadcasterPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/ActivityBroadcasterPlugin.kt
@@ -23,10 +23,7 @@ import com.rudderstack.core.Analytics
 import com.rudderstack.core.InfrastructurePlugin
 import java.util.concurrent.atomic.AtomicInteger
 
-/**
- * Tracks the Activities in the application and broadcasts the same
- *
- */
+/** Tracks the Activities in the application and broadcasts the same */
 internal class ActivityBroadcasterPlugin(
 ) : InfrastructurePlugin {
     private val application: Application?
@@ -40,11 +37,8 @@ internal class ActivityBroadcasterPlugin(
 
             override fun onActivityStarted(activity: Activity) {
                 incrementActivityCount()
-                if (analytics?.currentConfigurationAndroid?.recordScreenViews == true) {
-                    broadcastActivityStart(activity)
-                }
-                if(analytics?.currentConfigurationAndroid?.trackLifecycleEvents == true  &&
-                    activityCount.get() == 1) {
+                broadcastActivityStart(activity)
+                if (activityCount.get() == 1) {
                     broadCastApplicationStart()
                 }
             }
@@ -60,7 +54,7 @@ internal class ActivityBroadcasterPlugin(
             override fun onActivityStopped(activity: Activity) {
                 if (analytics?.currentConfigurationAndroid?.trackLifecycleEvents == true) {
                     decrementActivityCount()
-                    if(activityCount.get() == 0) {
+                    if (activityCount.get() == 0) {
                         broadCastApplicationStop()
                     }
                 }
@@ -99,7 +93,6 @@ internal class ActivityBroadcasterPlugin(
     private fun incrementActivityCount() {
         activityCount.incrementAndGet()
     }
-
 
 
     private fun broadCastApplicationStart() {


### PR DESCRIPTION
activity to be broadcasted even if recordScreenView or trackLifecycleEvents is false

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
