### PR TITLE
feat: add option to set anonymousId before SDK init

### DIFF
--- a/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
+++ b/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
@@ -67,7 +67,9 @@ fun Analytics.putDeviceToken(deviceToken: String) {
  *
  * @param anonymousId String to be used as anonymousId
  */
-fun Analytics.setAnonymousId(anonymousId: String) {
+
+// By changing to `internal` we are restricting the user from calling this API
+internal fun Analytics.setAnonymousId(anonymousId: String) {
     androidStorage.setAnonymousId(anonymousId)
     applyConfiguration {
         if (this is ConfigurationAndroid) copy(

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -3,6 +3,7 @@ package com.rudderstack.android.sampleapp.analytics
 import android.app.Application
 import com.rudderstack.android.BuildConfig
 import com.rudderstack.android.ConfigurationAndroid
+import com.rudderstack.android.RudderAnalytics
 import com.rudderstack.android.RudderAnalytics.Companion.getInstance
 import com.rudderstack.android.ruddermetricsreporterandroid.Configuration
 import com.rudderstack.android.ruddermetricsreporterandroid.DefaultRudderReporter
@@ -26,6 +27,7 @@ object RudderAnalyticsUtils {
 
     fun initialize(application: Application, listener: InitializationListener? = null) {
         //wen add work manager support to this instance
+        RudderAnalytics.setAnonymousId("sample-anonymous-id")
         _rudderAnalytics = getInstance(
             writeKey = WRITE_KEY,
             initializationListener = { success, message ->
@@ -41,6 +43,7 @@ object RudderAnalyticsUtils {
                 isPeriodicFlushEnabled = true
             )
         )
+//        RudderAnalytics.setAnonymousId("sample-anonymous-id")
         _rudderReporter = DefaultRudderReporter(
             context = application, baseUrl = METRICS_BASE_URL, configuration = Configuration(
                 LibraryMetadata(


### PR DESCRIPTION
## About the issue

- Previously, `setAnonymousId` could only be used to set the `anonymousId` after the SDK is init. If someone wants to set the ID before the SDK init then they need to pass the ID in the Configuration object. **This behaviour doesn't align with the v1.** Also, IMO, the setting of ID should not be part of the SDK configuration. And since we have a dedicated API to set this value, we should be utilising that API.

## About the change

- In this PR, we have made the existing `setAnonymousId` internal, in order to restrict the user from calling this API.
- Introduced a new `setAnonymousId` API similar to v1 which can be utilised to set the `advertisingId` either before or after the SDK init. This behaviour is in alignment with v1.

## Next change (Once this PR proposal is approved)

- We need to remove the `anonymousId` from the `Configuration` class.
- Make similar changes for other APIs e.g., `putDeviceToken`, `putAdvertisingId` etc.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
