### PR TITLE
fix: remove userId from the configurationAndroid class

### DIFF
--- a/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
+++ b/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
@@ -33,7 +33,6 @@ interface ConfigurationAndroid : Configuration {
      *
      * @property application
      * @property anonymousId
-     * @property userId
      * @property trackLifecycleEvents
      * @property recordScreenViews
      * @property isPeriodicFlushEnabled
@@ -62,7 +61,6 @@ interface ConfigurationAndroid : Configuration {
      */
     val application: Application
     val anonymousId: String?
-    val userId: String?
     val trackLifecycleEvents: Boolean
     val recordScreenViews: Boolean
     val isPeriodicFlushEnabled: Boolean
@@ -83,7 +81,6 @@ interface ConfigurationAndroid : Configuration {
             application: Application,
             jsonAdapter: JsonAdapter,
             anonymousId: String? = null,
-            userId: String? = null,
             options: RudderOption = RudderOption(),
             flushQueueSize: Int = Defaults.DEFAULT_FLUSH_QUEUE_SIZE,
             maxFlushInterval: Long = Defaults.DEFAULT_MAX_FLUSH_INTERVAL,
@@ -112,7 +109,6 @@ interface ConfigurationAndroid : Configuration {
             application,
             jsonAdapter,
             anonymousId,
-            userId,
             options,
             flushQueueSize,
             maxFlushInterval,
@@ -143,7 +139,6 @@ interface ConfigurationAndroid : Configuration {
             application: Application,
             jsonAdapter: JsonAdapter,
             anonymousId: String? = null,
-            userId: String? = null,
             options: RudderOption = RudderOption(),
             flushQueueSize: Int = Defaults.DEFAULT_FLUSH_QUEUE_SIZE,
             maxFlushInterval: Long = Defaults.DEFAULT_MAX_FLUSH_INTERVAL,
@@ -175,7 +170,6 @@ interface ConfigurationAndroid : Configuration {
         ): ConfigurationAndroid = object : ConfigurationAndroid {
             override val application: Application = application
             override val anonymousId: String? = anonymousId
-            override val userId: String? = userId
             override val trackLifecycleEvents: Boolean = trackLifecycleEvents
             override val recordScreenViews: Boolean = recordScreenViews
             override val isPeriodicFlushEnabled: Boolean = isPeriodicFlushEnabled
@@ -210,7 +204,6 @@ interface ConfigurationAndroid : Configuration {
             configuration: Configuration,
             application: Application,
             anonymousId: String = AndroidUtils.generateAnonymousId(Defaults.COLLECT_DEVICE_ID, application),
-            userId: String? = null,
             trackLifecycleEvents: Boolean = Defaults.TRACK_LIFECYCLE_EVENTS,
             recordScreenViews: Boolean = Defaults.RECORD_SCREEN_VIEWS,
             isPeriodicFlushEnabled: Boolean = Defaults.IS_PERIODIC_FLUSH_ENABLED,
@@ -229,7 +222,6 @@ interface ConfigurationAndroid : Configuration {
                 application,
                 configuration.jsonAdapter,
                 anonymousId,
-                userId,
                 configuration.options,
                 configuration.flushQueueSize,
                 configuration.maxFlushInterval,
@@ -302,7 +294,6 @@ interface ConfigurationAndroid : Configuration {
         networkExecutor: ExecutorService = this.networkExecutor,
         base64Generator: Base64Generator = this.base64Generator,
         anonymousId: String? = this.anonymousId,
-        userId: String? = this.userId,
         advertisingId: String? = this.advertisingId,
         autoCollectAdvertId: Boolean = this.autoCollectAdvertId,
         deviceToken: String? = this.deviceToken,
@@ -313,7 +304,6 @@ interface ConfigurationAndroid : Configuration {
             application,
             jsonAdapter,
             anonymousId,
-            userId,
             options,
             flushQueueSize,
             maxFlushInterval,

--- a/android/src/main/java/com/rudderstack/android/compat/ConfigurationAndroidBuilder.java
+++ b/android/src/main/java/com/rudderstack/android/compat/ConfigurationAndroidBuilder.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 public class ConfigurationAndroidBuilder extends ConfigurationBuilder {
     private final Application application ;
     private String anonymousId;
-    private String userId = null;
     private Boolean trackLifecycleEvents = ConfigurationAndroid.Defaults.TRACK_LIFECYCLE_EVENTS;
     private Boolean recordScreenViews  = ConfigurationAndroid.Defaults.RECORD_SCREEN_VIEWS;
     private Boolean isPeriodicFlushEnabled  = ConfigurationAndroid.Defaults.IS_PERIODIC_FLUSH_ENABLED;
@@ -52,10 +51,6 @@ public class ConfigurationAndroidBuilder extends ConfigurationBuilder {
     }
     public ConfigurationBuilder withAnonymousId(String anonymousId) {
         this.anonymousId = anonymousId;
-        return this;
-    }
-    public ConfigurationBuilder withUserId(String userId) {
-        this.userId = userId;
         return this;
     }
     public ConfigurationBuilder withTrackLifecycleEvents(Boolean trackLifecycleEvents) {
@@ -118,7 +113,6 @@ public class ConfigurationAndroidBuilder extends ConfigurationBuilder {
         return ConfigurationAndroid.Companion.invoke(super.build(),
                 application,
                 anonymousId,
-                userId,
                 trackLifecycleEvents,
                 recordScreenViews,
                 isPeriodicFlushEnabled,

--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/ReinstatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/ReinstatePlugin.kt
@@ -22,7 +22,6 @@ import com.rudderstack.android.utilities.currentConfigurationAndroid
 import com.rudderstack.android.utilities.initializeSessionManagement
 import com.rudderstack.android.utilities.processNewContext
 import com.rudderstack.android.utilities.setAnonymousId
-import com.rudderstack.android.utilities.setUserId
 import com.rudderstack.core.Analytics
 import com.rudderstack.core.DataUploadService
 import com.rudderstack.core.InfrastructurePlugin
@@ -97,7 +96,7 @@ internal class ReinstatePlugin : InfrastructurePlugin {
             _analytics?.processNewContext(context)
         }
         userId?.let {
-            _analytics?.setUserId(it)
+            _analytics?.androidStorage?.setUserId(it)
         }
         if (anonId != null)
             _analytics?.setAnonymousId(anonId)
@@ -146,7 +145,7 @@ internal class ReinstatePlugin : InfrastructurePlugin {
         val traits = androidStorage.v1Traits
         val userId = traits?.get("userId") as? String ?: traits?.get("id") as? String
         if (userId.isNullOrEmpty() || !this.androidStorage.userId.isNullOrEmpty()) return
-        _analytics?.setUserId(userId)
+        androidStorage.setUserId(userId)
     }
 
     private fun Analytics.migrateAnonymousIdFromV1() {

--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/ReinstatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/ReinstatePlugin.kt
@@ -83,7 +83,6 @@ internal class ReinstatePlugin : InfrastructurePlugin {
     }
 
     private fun reinstateV2FromCache() {
-        val userId = _analytics?.androidStorage?.userId
         val anonId = _analytics?.androidStorage?.anonymousId
             ?: _analytics?.currentConfigurationAndroid?.let {
                 AndroidUtils.generateAnonymousId(
@@ -94,9 +93,6 @@ internal class ReinstatePlugin : InfrastructurePlugin {
         val context = _analytics?.androidStorage?.context
         context?.let {
             _analytics?.processNewContext(context)
-        }
-        userId?.let {
-            _analytics?.androidStorage?.setUserId(it)
         }
         if (anonId != null)
             _analytics?.setAnonymousId(anonId)

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
@@ -17,6 +17,7 @@ package com.rudderstack.android.internal.plugins
 import com.rudderstack.android.utilities.androidStorage
 import com.rudderstack.android.utilities.contextState
 import com.rudderstack.android.utilities.currentConfigurationAndroid
+import com.rudderstack.android.utilities.empty
 import com.rudderstack.android.utilities.processNewContext
 import com.rudderstack.core.Analytics
 import com.rudderstack.core.Plugin
@@ -65,7 +66,7 @@ internal class ExtractStatePlugin : Plugin {
             val newUserId = getUserId(message)
 
             _analytics?.rudderLogger?.debug(log = "New user id detected: $newUserId")
-            val prevId = _analytics?.androidStorage?.userId ?: _analytics?.currentConfigurationAndroid?.anonymousId ?: ""
+            val prevId = _analytics?.androidStorage?.userId ?: _analytics?.currentConfigurationAndroid?.anonymousId ?: String.empty()
             // in case of identify, the stored traits (if any) are replaced by the ones provided
             // if user id is different. else traits are added to it
             val msg = when (message) {

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
@@ -14,6 +14,7 @@
 
 package com.rudderstack.android.internal.plugins
 
+import com.rudderstack.android.utilities.androidStorage
 import com.rudderstack.android.utilities.contextState
 import com.rudderstack.android.utilities.currentConfigurationAndroid
 import com.rudderstack.android.utilities.processNewContext
@@ -65,9 +66,7 @@ internal class ExtractStatePlugin : Plugin {
             val newUserId = getUserId(message)
 
             _analytics?.rudderLogger?.debug(log = "New user id detected: $newUserId")
-            val prevId = _analytics?.currentConfigurationAndroid?.let {
-                it.userId ?: it.anonymousId
-            } ?: ""
+            val prevId = _analytics?.androidStorage?.userId ?: _analytics?.currentConfigurationAndroid?.anonymousId ?: ""
             // in case of identify, the stored traits (if any) are replaced by the ones provided
             // if user id is different. else traits are added to it
             val msg = when (message) {

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/ExtractStatePlugin.kt
@@ -18,7 +18,6 @@ import com.rudderstack.android.utilities.androidStorage
 import com.rudderstack.android.utilities.contextState
 import com.rudderstack.android.utilities.currentConfigurationAndroid
 import com.rudderstack.android.utilities.processNewContext
-import com.rudderstack.android.utilities.setUserId
 import com.rudderstack.core.Analytics
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.optAdd
@@ -94,7 +93,7 @@ internal class ExtractStatePlugin : Plugin {
             }?:message
             msg.also {
                 newUserId?.let { id ->
-                    _analytics?.setUserId(id)
+                    _analytics?.androidStorage?.setUserId(id)
                 }
             }
             return chain.proceed(msg)

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
@@ -14,6 +14,7 @@
 
 package com.rudderstack.android.internal.plugins
 
+import com.rudderstack.android.utilities.androidStorage
 import com.rudderstack.android.utilities.contextState
 import com.rudderstack.android.utilities.currentConfigurationAndroid
 import com.rudderstack.core.Analytics
@@ -51,7 +52,7 @@ internal class FillDefaultsPlugin : Plugin {
     @Throws(MissingPropertiesException::class)
     private inline fun <reified T : Message> T.withDefaults(): T {
         val anonId = this.anonymousId ?: _analytics?.currentConfigurationAndroid?.anonymousId
-        val userId = this.userId ?: _analytics?.currentConfigurationAndroid?.userId
+        val userId = this.userId ?: _analytics?.androidStorage?.userId
         if (anonId == null && userId == null) {
             val ex = MissingPropertiesException("Either Anonymous Id or User Id must be present");
             _analytics?.currentConfigurationAndroid?.rudderLogger?.error(
@@ -64,7 +65,7 @@ internal class FillDefaultsPlugin : Plugin {
         val newContext =
                 // in case of alias we purposefully remove traits from context
                 _analytics?.contextState?.value?.let {
-                    if (this is AliasMessage && this.userId != _analytics?.currentConfigurationAndroid?.userId) it.updateWith(
+                    if (this is AliasMessage && this.userId != _analytics?.androidStorage?.userId) it.updateWith(
                         traits = mapOf()
                     ) else it
                 } selectiveReplace context.let {

--- a/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
+++ b/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
@@ -143,3 +143,5 @@ private fun Analytics.attachSavedContextIfAvailable() {
         processNewContext(it)
     }
 }
+
+fun String.Companion.empty(): String = ""

--- a/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
+++ b/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
@@ -92,12 +92,6 @@ fun Analytics.setAnonymousId(anonymousId: String) {
  */
 fun Analytics.setUserId(userId: String) {
     androidStorage.setUserId(userId)
-    applyConfiguration {
-        if (this is ConfigurationAndroid) copy(
-            userId = userId
-        )
-        else this
-    }
 }
 
 private val infrastructurePlugins = arrayOf(

--- a/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
+++ b/android/src/main/java/com/rudderstack/android/utilities/AnalyticsUtil.kt
@@ -85,15 +85,6 @@ fun Analytics.setAnonymousId(anonymousId: String) {
     processNewContext(newContext)
 }
 
-/**
- * Setting the [ConfigurationAndroid.userId] explicitly.
- *
- * @param userId String to be used as userId
- */
-fun Analytics.setUserId(userId: String) {
-    androidStorage.setUserId(userId)
-}
-
 private val infrastructurePlugins = arrayOf(
     ReinstatePlugin(),
     AnonymousIdHeaderPlugin(),


### PR DESCRIPTION
## Description

In this PR, we removed `userId` from the `ConfigurationAndroid` class and also made some other optimisation i.e., now we are directly saving the userId in the storage and now we no longer need to call Analytics.setUserId to save this value. Also fixed one failing test case.

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
