### PR TITLE
fix: database crash issue

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/DBPersistentManager.java
@@ -16,7 +16,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import com.rudderstack.android.ruddermetricsreporterandroid.RudderReporter;
 import com.rudderstack.android.sdk.core.persistence.DefaultPersistenceProviderFactory;
 import com.rudderstack.android.sdk.core.persistence.Persistence;
 import com.rudderstack.android.sdk.core.persistence.PersistenceProvider;
@@ -26,11 +25,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -43,7 +40,6 @@ import java.util.concurrent.Semaphore;
 class DBPersistentManager/* extends SQLiteOpenHelper*/ {
 
     public static final String DBPERSISTENT_MANAGER_CHECK_FOR_MIGRATIONS_TAG = "DBPersistentManager: checkForMigrations: ";
-    public static final Object QUEUE_LOCK = new Object();
     public static final ExecutorService executor = Executors.newSingleThreadExecutor();
     static final String EVENT = "EVENT";
 
@@ -100,8 +96,7 @@ class DBPersistentManager/* extends SQLiteOpenHelper*/ {
     //synchronizing database access
     private static final Object DB_LOCK = new Object();
     private static DBPersistentManager instance;
-    final Queue<Message> queue = new LinkedList<>();
-    DBInsertionHandlerThread dbInsertionHandlerThread;
+    private DBInsertionHandlerThread dbInsertionHandlerThread;
     private Persistence persistence;
 
     private DBPersistentManager(Application application,
@@ -190,18 +185,18 @@ class DBPersistentManager/* extends SQLiteOpenHelper*/ {
 
 
     /*
-     * Receives message from Repository, and passes it to the Handler thread if it exists, else adds it to a queue for replay
-     * once Handler thread is initialized.
+     * Receives message from Repository, and passes it to the Handler thread if it exists else creates a new Handler thread.
+     * This method should be called in a synchronized way.
      * */
     void saveEvent(String messageJson, EventInsertionCallback callback) {
         Message msg = createOsMessageFromJson(messageJson, callback);
-        synchronized (DBPersistentManager.QUEUE_LOCK) {
-            if (dbInsertionHandlerThread == null) {
-                queue.add(msg);
-                return;
-            }
-            addMessageToHandlerThread(msg);
+        if (dbInsertionHandlerThread == null) {
+            // Need to perform db operations on a separate thread to support strict mode.
+            // saveEvent method is already called on an executor thread, so we can directly call DBInsertionHandlerThread
+            dbInsertionHandlerThread = new DBInsertionHandlerThread("db_insertion_thread", persistence);
+            dbInsertionHandlerThread.start();
         }
+        dbInsertionHandlerThread.addMessage(msg);
     }
 
     private Message createOsMessageFromJson(String messageJson, EventInsertionCallback callback) {
@@ -211,13 +206,6 @@ class DBPersistentManager/* extends SQLiteOpenHelper*/ {
         eventBundle.putString(EVENT, messageJson);
         msg.setData(eventBundle);
         return msg;
-    }
-
-    /*
-       Passes the input message to the Handler thread.
-     */
-    void addMessageToHandlerThread(Message msg) {
-        dbInsertionHandlerThread.addMessage(msg);
     }
 
     @VisibleForTesting
@@ -455,32 +443,6 @@ class DBPersistentManager/* extends SQLiteOpenHelper*/ {
 
         return count;
     }
-
-    /*
-       Starts the Handler thread, which is responsible for storing the messages in its internal queue, and
-       save them to the sqlite db sequentially.
-     */
-    void startHandlerThread() {
-        Runnable runnable = () -> {
-            try {
-                synchronized (DBPersistentManager.QUEUE_LOCK) {
-                    dbInsertionHandlerThread = new DBInsertionHandlerThread("db_insertion_thread", persistence);
-                    dbInsertionHandlerThread.start();
-                    for (Message msg : queue) {
-                        addMessageToHandlerThread(msg);
-                    }
-                }
-            } catch (SQLiteDatabaseCorruptException | ConcurrentModificationException |
-                     NullPointerException ex) {
-                RudderLogger.logError(ex);
-                ReportManager.reportError(ex);
-
-            }
-        };
-        // Need to perform db operations on a separate thread to support strict mode.
-        executor.execute(runnable);
-    }
-
 
     private boolean checkIfColumnExists(String newColumn) {
         String checkIfStatusExistsSqlString = "PRAGMA table_info(events)";

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -214,7 +214,6 @@ class EventRepository {
                 dbEncryption.getPersistenceProviderFactoryClassName(), dbEncryption.key);
         this.dbManager = DBPersistentManager.getInstance(application, dbManagerParams);
         dbManager.checkForMigrations();
-        dbManager.startHandlerThread();
     }
 
     private void initiatePreferenceManager(Application application) {

--- a/core/src/test/java/com/rudderstack/android/sdk/core/DBPersistentManagerTest.java
+++ b/core/src/test/java/com/rudderstack/android/sdk/core/DBPersistentManagerTest.java
@@ -6,46 +6,29 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.reflect.Whitebox;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import android.os.Build;
-import android.os.Message;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasProperty;
-import static java.lang.Thread.sleep;
 
 import android.app.Application;
 
 import androidx.test.core.app.ApplicationProvider;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import com.google.common.collect.ImmutableList;
 import com.rudderstack.android.sdk.core.gson.RudderGson;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.O_MR1)
@@ -84,8 +67,6 @@ public class DBPersistentManagerTest {
         dbPersistentManager = PowerMockito.mock(DBPersistentManager.class);
         PowerMockito.when(dbPersistentManager, "saveEventSync", anyString()).thenCallRealMethod();
         PowerMockito.when(dbPersistentManager, "saveEvent", anyString(), any()).thenCallRealMethod();
-        PowerMockito.when(dbPersistentManager, "startHandlerThread").thenCallRealMethod();
-        Whitebox.setInternalState(dbPersistentManager, "queue", new LinkedList<Message>());
         deviceModeManager = Mockito.mock(RudderDeviceModeManager.class);
     }
 
@@ -98,57 +79,6 @@ public class DBPersistentManagerTest {
 
     private int addMessageCalled = 0;
 
-    @Test
-    public void testSynchronicity() throws Exception {
-        final AtomicInteger messagesSaved = new AtomicInteger(0);
-        // Mocking the addMessageToQueue, which is used by both the save-event-thread and Handler thread, to verify synchronization
-        PowerMockito.when(dbPersistentManager, "addMessageToHandlerThread", any(Message.class))
-                .thenAnswer((Answer<Void>) invocation -> {
-                    ++addMessageCalled;
-                    System.out.println("addMessageToQueue called by: " + Thread.currentThread().getName());
-                    //assert if called by multiple thread
-                    assertThat(addMessageCalled, Matchers.lessThan(2));
-                    sleep(500);
-                    --addMessageCalled;
-                    assertThat(addMessageCalled, Matchers.lessThan(1));
-                    System.out.println("return from addMessageToQueue by: " + Thread.currentThread().getName());
-                    messagesSaved.incrementAndGet();
-                    return null;
-                }
-                );
-
-        // Triggering the saveEvent method of DBPersistentManager from save-event-thread, as this method adds messages to the queue.
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                for (int i = 0; i < messages.size(); i++) {
-                    dbPersistentManager.saveEvent(messages.get(i),
-                            new EventInsertionCallback(new RudderMessageBuilder().build(),
-                                    deviceModeManager));
-                    // Starting the Handler thread, only when some events are added to the queue, so that the replay happens, and handler
-                    // thread starts reading from the queue.
-                    if (i == messages.size() / 2) {
-                        dbPersistentManager.startHandlerThread();
-                        try {
-                            Thread.sleep(200);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-            }
-        }, "save-event-thread") {
-        }.start();
-
-
-        //await until finished
-        await().atMost(15, SECONDS).until(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return messagesSaved.get() == messages.size();
-            }
-        });
-    }
     @Test
     public void doneEventsTest() {
         final DBPersistentManager dbPersistentManager = DBPersistentManager.getInstance(ApplicationProvider

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,19 +1,1 @@
 include ':sample-cdn', ':sample-kotlin', ':core', ':sample-segment-java', ':sample-kotlin-integration', ':dummy-impl', ':android-tv'
-//include(':web')
-//project(':web').projectDir = new File(rootDir, "../RudderAndroidLibs/web")
-////
-//include(':rudderjsonadapter')
-//project(':rudderjsonadapter').projectDir = new File(rootDir, "../RudderAndroidLibs/rudderjsonadapter")
-//include(':gsonrudderadapter')
-//project(':gsonrudderadapter').projectDir = new File(rootDir, "../RudderAndroidLibs/gsonrudderadapter")
-//include(':moshirudderadapter')
-//project(':moshirudderadapter').projectDir = new File(rootDir, "../RudderAndroidLibs/moshirudderadapter")
-//include(':jacksonrudderadapter')
-//project(':jacksonrudderadapter').projectDir = new File(rootDir, "../RudderAndroidLibs/jacksonrudderadapter")
-////
-//include(':repository')
-//project(':repository').projectDir = new File(rootDir, "../RudderAndroidLibs/repository")
-////
-//include(':rudderreporter')
-//project(':rudderreporter').projectDir = new File(rootDir, "../RudderAndroidLibs/rudderreporter")
-


### PR DESCRIPTION
## Description

In this PR, we attempt to fix the DB crash issue occurring for a few % of users. This happens while the SDK is being initialised. We have removed the queue-related logic to prevent any hidden thread-related issues. Additionally, since we are now calling `saveEvent()` from the executor in the repository class, we no longer need a separate executor for the `DBInsertionHandlerThread` instance creation.

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
