### PR TITLE
fix: screen event

### DIFF
--- a/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
+++ b/android/src/main/java/com/rudderstack/android/ConfigurationAndroid.kt
@@ -352,7 +352,7 @@ interface ConfigurationAndroid : Configuration {
         const val GZIP_ENABLED: Boolean = true
         const val SHOULD_VERIFY_SDK: Boolean = true
         const val TRACK_LIFECYCLE_EVENTS = true
-        const val RECORD_SCREEN_VIEWS = true
+        const val RECORD_SCREEN_VIEWS = false
         const val IS_PERIODIC_FLUSH_ENABLED = false
         const val AUTO_COLLECT_ADVERT_ID = false
         const val MULTI_PROCESS_ENABLED = false

--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/LifecycleObserverPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/LifecycleObserverPlugin.kt
@@ -31,6 +31,8 @@ const val EVENT_NAME_APPLICATION_OPENED = "Application Opened"
 const val EVENT_NAME_APPLICATION_STOPPED = "Application Backgrounded"
 private const val MAX_CONFIG_DOWNLOAD_INTERVAL = 90 * 60 * 1000 // 90 MINUTES
 
+private const val AUTOMATIC = "automatic"
+
 /**
  * We use a [Plugin] instead of [InfrastructurePlugin] as sending events from Infrastructure plugin might
  * not ensure all plugins to be ready
@@ -126,6 +128,9 @@ internal class LifecycleObserverPlugin(val currentMillisGenerator: (() -> Long) 
         withTrackLifeCycleAndRecordScreenViews {
             analytics?.screen {
                 screenName(activityName)
+                screenProperties {
+                    add(AUTOMATIC to true)
+                }
             }
         }
     }

--- a/android/src/test/java/com/rudderstack/android/internal/infrastructure/LifecycleObserverPluginTest.kt
+++ b/android/src/test/java/com/rudderstack/android/internal/infrastructure/LifecycleObserverPluginTest.kt
@@ -11,6 +11,7 @@ import com.rudderstack.core.internal.KotlinLogger
 import com.rudderstack.gsonrudderadapter.GsonAdapter
 import com.rudderstack.jacksonrudderadapter.JacksonAdapter
 import com.rudderstack.models.RudderServerConfig
+import com.rudderstack.models.ScreenMessage
 import com.rudderstack.models.TrackMessage
 import com.rudderstack.models.TrackProperties
 import com.rudderstack.rudderjsonadapter.JsonAdapter
@@ -168,6 +169,32 @@ abstract class LifecycleObserverPluginTest {
         org.mockito.kotlin.verify(mockControlPlane).download(any())
         plugin.onShutDown()
 
+    }
+
+    @Test
+    fun `given automatic screen event is enabled, when automatic screen event is made, then screen event containing default properties is sent`() {
+        val plugin = LifecycleObserverPlugin()
+        plugin.setup(analytics)
+
+        plugin.onActivityStarted("MainActivity")
+
+        analytics.assertArgument { input, _ ->
+            assertThat(
+                input, allOf(
+                    isA(ScreenMessage::class.java),
+                    hasProperty("eventName", `is`("MainActivity")),
+                    hasProperty(
+                        "properties", allOf<TrackProperties>(
+                            aMapWithSize(2),
+                            hasEntry("automatic", true),
+                            hasEntry("name", "MainActivity"),
+                        )
+                    )
+                )
+            )
+        }
+
+        plugin.onShutDown()
     }
 }
 

--- a/android/src/test/java/com/rudderstack/android/storage/MessageEntityTest.kt
+++ b/android/src/test/java/com/rudderstack/android/storage/MessageEntityTest.kt
@@ -121,11 +121,11 @@ Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinatio
 @Test
     fun testGenerateContentValuesForScreen() {
         val testMessage = ScreenMessage.create(
+            name = "testScreen",
             RudderUtils.timeStamp,
             "testAnonymousId",
             "testUserId",
             mapOf("dest1" to mapOf("key1" to "value1")),
-            name = "testScreen",
             category = "testCategory",
             mapOf("testKey" to "testValue"),
             mapOf("key2" to mapOf("some_key" to "some_value")),

--- a/android/src/test/java/com/rudderstack/android/storage/MigrateV1ToV2UtilsTest.kt
+++ b/android/src/test/java/com/rudderstack/android/storage/MigrateV1ToV2UtilsTest.kt
@@ -390,7 +390,7 @@ abstract class MigrateV1ToV2UtilsTest {
                 Matchers.notNullValue(),
                 hasProperty("messageId", Matchers.equalTo(v1Entity1.v1Message.messageId)),
                 hasProperty("channel", Matchers.equalTo(v1Entity1.v1Message.channel)),
-                not(hasProperty("eventName", Matchers.equalTo(v1Entity1.v1Message.event))),
+                hasProperty("eventName", Matchers.equalTo(v1Entity1.v1Message.event)),
                 hasProperty(
                     "type", Matchers.equalTo(
                         Message.EventType.fromValue(

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -72,7 +72,8 @@ class ScreenScope internal constructor() : MessageScope<ScreenMessage>() {
         category = name
     }
     override val message: ScreenMessage
-        get() = ScreenMessage.create(RudderUtils.timeStamp, name = screenName, category = category,
+        get() = ScreenMessage.create(screenName ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
+                RudderUtils.timeStamp, category = category,
             anonymousId = anonymousId,
         properties = screenProperties, userId = userId, destinationProps = destinationProperties)
 

--- a/models/src/main/java/com/rudderstack/models/Message.kt
+++ b/models/src/main/java/com/rudderstack/models/Message.kt
@@ -524,10 +524,12 @@ class ScreenMessage internal constructor(
      */
 
     @SerializedName("properties") @JsonProperty("properties") @Json(name = "properties") val properties: ScreenProperties? = null,
+    @SerializedName("event") @field:JsonProperty("event") @param:JsonProperty("event") @get:JsonProperty(
+        "event"
+    ) @Json(name = "event") val eventName: String? = null,
     @JsonProperty("not_applicable", required = false) // work-around to ignore value param
     // jackson serialisation
     _messageId: String? = null,
-
     ) : Message(
     EventType.SCREEN,
     context,
@@ -540,16 +542,13 @@ class ScreenMessage internal constructor(
     companion object {
         @JvmStatic
         fun create(
-
+            name: String? = null,
             timestamp: String,
             anonymousId: String? = null,
             userId: String? = null,
-
             destinationProps: MessageDestinationProps? = null,
-            name: String? = null,
             category: String? = null,
             properties: ScreenProperties? = null,
-
             traits: Map<String, Any?>? = null,
             externalIds: List<Map<String, String>>? = null,
             customContextMap: Map<String, Any>? = null,
@@ -562,6 +561,7 @@ class ScreenMessage internal constructor(
             }.let {
                 if (category != null) it.plus("category" to category) else it
             },
+            name,
             _messageId,
         )
     }
@@ -575,7 +575,7 @@ class ScreenMessage internal constructor(
         name: String? = this.properties?.get("name") as String?,
         category: String? = this.properties?.get("category") as String?,
         properties: ScreenProperties? = this.properties,
-
+        eventName: String? = this.eventName,
         ) = ScreenMessage(
         context, anonymousId, userId, timestamp, destinationProps,
         (properties ?: ScreenProperties()).let {
@@ -583,6 +583,7 @@ class ScreenMessage internal constructor(
         }.let {
             if (category != null) it.plus("category" to category) else it
         },
+        eventName,
         _messageId = this.messageId,
     )
 

--- a/models/src/main/java/com/rudderstack/models/Message.kt
+++ b/models/src/main/java/com/rudderstack/models/Message.kt
@@ -542,7 +542,7 @@ class ScreenMessage internal constructor(
     companion object {
         @JvmStatic
         fun create(
-            name: String? = null,
+            name: String,
             timestamp: String,
             anonymousId: String? = null,
             userId: String? = null,


### PR DESCRIPTION
## Description

- Set default flag value to `false` for the `Automatic Screen Event`.
- Send default property (i.e., `automatic` to `true`) for the `Automatic Screen Event`. Also, add a unit test case for the `Automatic Screen Event`.
- Allow setting of `eventName` in screen event. This property will be set in the root as follows:
```
"event": "mainview.MainActivity"
```
<img width="1241" alt="image" src="https://github.com/rudderlabs/rudder-sdk-android/assets/64667840/4fbe2e9c-47f7-4027-9f86-e256ae0e999f">
- Also fixed a few failing test cases related to the screen event.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
