### PR TITLE
feat: remove PageMessage and PAGE event type

### DIFF
--- a/android/src/main/java/com/rudderstack/android/storage/MessageEntity.kt
+++ b/android/src/main/java/com/rudderstack/android/storage/MessageEntity.kt
@@ -25,7 +25,6 @@ import com.rudderstack.models.AliasMessage
 import com.rudderstack.models.GroupMessage
 import com.rudderstack.models.IdentifyMessage
 import com.rudderstack.models.Message
-import com.rudderstack.models.PageMessage
 import com.rudderstack.models.ScreenMessage
 import com.rudderstack.models.TrackMessage
 import com.rudderstack.rudderjsonadapter.JsonAdapter
@@ -45,9 +44,11 @@ import com.rudderstack.rudderjsonadapter.RudderTypeAdapter
         RudderField(RudderField.Type.INTEGER, MessageEntity.ColumnNames.status),
     ]
 )
-internal class MessageEntity(val message: Message,
-                             private val jsonAdapter: JsonAdapter,
-    private val updatedAt: Long? = null) : Entity {
+internal class MessageEntity(
+    val message: Message,
+    private val jsonAdapter: JsonAdapter,
+    private val updatedAt: Long? = null
+) : Entity {
     object ColumnNames {
         internal const val messageId = "id"
         internal const val message = "message"
@@ -55,11 +56,12 @@ internal class MessageEntity(val message: Message,
         internal const val type = "type"
         internal const val status = "status"
     }
+
     val status: Int
         get() = _status
     private var _status: Int = STATUS_NEW
 
-    fun maskWithDmtStatus(dmtStatus: Int){
+    fun maskWithDmtStatus(dmtStatus: Int) {
         _status = _status.maskWith(dmtStatus)
     }
 
@@ -71,7 +73,7 @@ internal class MessageEntity(val message: Message,
                 jsonAdapter.writeToJson(message, RudderTypeAdapter<Message> {})
                     ?.replace("'", BACKLASHES_INVERTED_COMMA)
             )
-            it.put(ColumnNames.updatedAt, updatedAt?: System.currentTimeMillis())
+            it.put(ColumnNames.updatedAt, updatedAt ?: System.currentTimeMillis())
             it.put(ColumnNames.type, message.getType().value)
             it.put(ColumnNames.status, _status)
         }
@@ -95,7 +97,7 @@ internal class MessageEntity(val message: Message,
             return MessageEntity(
                 message ?: return null,
                 jsonAdapter
-            ).also {entity ->
+            ).also { entity ->
                 status?.let {
                     entity.maskWithDmtStatus(it)
                 }
@@ -107,7 +109,6 @@ internal class MessageEntity(val message: Message,
                 Message.EventType.ALIAS.value -> AliasMessage::class.java
                 Message.EventType.GROUP.value -> GroupMessage::class.java
                 Message.EventType.IDENTIFY.value -> IdentifyMessage::class.java
-                Message.EventType.PAGE.value -> PageMessage::class.java
                 Message.EventType.SCREEN.value -> ScreenMessage::class.java
                 Message.EventType.TRACK.value -> TrackMessage::class.java
                 else -> Message::class.java

--- a/android/src/test/java/com/rudderstack/android/storage/MessageEntityTest.kt
+++ b/android/src/test/java/com/rudderstack/android/storage/MessageEntityTest.kt
@@ -22,6 +22,7 @@ import org.robolectric.annotation.Config
 
 abstract class MessageEntityTest {
     abstract val jsonAdapter: JsonAdapter
+
     @Test
     fun testGenerateContentValuesForTrack() {
         val testMessage = TrackMessage.create(
@@ -42,19 +43,21 @@ abstract class MessageEntityTest {
         val regainedEntity = MessageEntity.create(contentValues.keySet().associateWith {
             contentValues.getAsString(it)
         }, jsonAdapter)
-        MatcherAssert.assertThat(regainedEntity?.message, Matchers.allOf(
-            Matchers.notNullValue(),
-            Matchers.instanceOf(TrackMessage::class.java),
-            Matchers.hasProperty("eventName", Matchers.equalTo("testEvent")),
-            Matchers.hasProperty("anonymousId", Matchers.equalTo("testAnonymousId")),
-            Matchers.hasProperty("userId", Matchers.equalTo("testUserId")),
-            Matchers.hasProperty("properties", Matchers.hasEntry("testKey", "testValue")),
-            Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
-Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
-Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
-
-        ))
+        MatcherAssert.assertThat(
+            regainedEntity?.message, Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(TrackMessage::class.java),
+                Matchers.hasProperty("eventName", Matchers.equalTo("testEvent")),
+                Matchers.hasProperty("anonymousId", Matchers.equalTo("testAnonymousId")),
+                Matchers.hasProperty("userId", Matchers.equalTo("testUserId")),
+                Matchers.hasProperty("properties", Matchers.hasEntry("testKey", "testValue")),
+                Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
+                Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
+                Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
+            )
+        )
     }
+
     @Test
     fun testGenerateContentValuesForGroup() {
         val testMessage = GroupMessage.create(
@@ -75,20 +78,23 @@ Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinatio
         val regainedEntity = MessageEntity.create(contentValues.keySet().associateWith {
             contentValues.getAsString(it)
         }, jsonAdapter)
-        MatcherAssert.assertThat(regainedEntity?.message, Matchers.allOf(
-            Matchers.notNullValue(),
-            Matchers.instanceOf(GroupMessage::class.java),
-            Matchers.hasProperty("groupId", Matchers.equalTo(testMessage.groupId)),
-            Matchers.hasProperty("anonymousId", Matchers.equalTo(testMessage.anonymousId)),
-            Matchers.hasProperty("userId", Matchers.equalTo(testMessage.userId)),
-            Matchers.hasProperty("traits", Matchers.hasEntry("testKey", "testValue")),
-            Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
-Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
-Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
+        MatcherAssert.assertThat(
+            regainedEntity?.message, Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(GroupMessage::class.java),
+                Matchers.hasProperty("groupId", Matchers.equalTo(testMessage.groupId)),
+                Matchers.hasProperty("anonymousId", Matchers.equalTo(testMessage.anonymousId)),
+                Matchers.hasProperty("userId", Matchers.equalTo(testMessage.userId)),
+                Matchers.hasProperty("traits", Matchers.hasEntry("testKey", "testValue")),
+                Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
+                Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
+                Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
 
-        ))
+                )
+        )
     }
-@Test
+
+    @Test
     fun testGenerateContentValuesForIdentify() {
         val testMessage = IdentifyMessage.create(
             "testAnonymousId",
@@ -106,19 +112,22 @@ Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinatio
         val regainedEntity = MessageEntity.create(contentValues.keySet().associateWith {
             contentValues.getAsString(it)
         }, jsonAdapter)
-        MatcherAssert.assertThat(regainedEntity?.message, Matchers.allOf(
-            Matchers.notNullValue(),
-            Matchers.instanceOf(IdentifyMessage::class.java),
-            Matchers.hasProperty("anonymousId", Matchers.equalTo(testMessage.anonymousId)),
-            Matchers.hasProperty("userId", Matchers.equalTo(testMessage.userId)),
-            Matchers.hasProperty("properties", Matchers.hasEntry("testKey", "testValue")),
-            Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
-Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
-Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
+        MatcherAssert.assertThat(
+            regainedEntity?.message, Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(IdentifyMessage::class.java),
+                Matchers.hasProperty("anonymousId", Matchers.equalTo(testMessage.anonymousId)),
+                Matchers.hasProperty("userId", Matchers.equalTo(testMessage.userId)),
+                Matchers.hasProperty("properties", Matchers.hasEntry("testKey", "testValue")),
+                Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
+                Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
+                Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
 
-        ))
+                )
+        )
     }
-@Test
+
+    @Test
     fun testGenerateContentValuesForScreen() {
         val testMessage = ScreenMessage.create(
             RudderUtils.timeStamp,
@@ -138,17 +147,18 @@ Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinatio
         val regainedEntity = MessageEntity.create(contentValues.keySet().associateWith {
             contentValues.getAsString(it)
         }, jsonAdapter)
-        MatcherAssert.assertThat(regainedEntity?.message, Matchers.allOf(
-            Matchers.notNullValue(),
-            Matchers.instanceOf(ScreenMessage::class.java),
-            Matchers.hasProperty("anonymousId", Matchers.equalTo(testMessage.anonymousId)),
-            Matchers.hasProperty("userId", Matchers.equalTo(testMessage.userId)),
-            Matchers.hasProperty("properties", Matchers.hasEntry("testKey", "testValue")),
-            Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
-Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
-Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
-
-        ))
+        MatcherAssert.assertThat(
+            regainedEntity?.message, Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(ScreenMessage::class.java),
+                Matchers.hasProperty("anonymousId", Matchers.equalTo(testMessage.anonymousId)),
+                Matchers.hasProperty("userId", Matchers.equalTo(testMessage.userId)),
+                Matchers.hasProperty("properties", Matchers.hasEntry("testKey", "testValue")),
+                Matchers.hasProperty("messageId", Matchers.equalTo(testMessage.messageId)),
+                Matchers.hasProperty("context", Matchers.equalTo(testMessage.context)),
+                Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinationProps)),
+            )
+        )
     }
 
     @Test
@@ -169,6 +179,7 @@ Matchers.hasProperty("destinationProps", Matchers.equalTo(testMessage.destinatio
         MatcherAssert.assertThat(primaryKeyValues, Matchers.arrayContaining(testMessage.messageId))
     }
 }
+
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [29])
 class GsonEntityTest : MessageEntityTest() {
@@ -182,13 +193,6 @@ class JacksonEntityTest : MessageEntityTest() {
     override val jsonAdapter: JsonAdapter
         get() = JacksonAdapter()
 }
-
-/*@RunWith(AndroidJUnit4::class)
-@Config(sdk = [29])
-class MoshiEntityTest : MessageEntityTest() {
-    override val jsonAdapter: JsonAdapter
-        get() = MoshiAdapter()
-}*/
 
 @RunWith(Suite::class)
 @Suite.SuiteClasses(

--- a/models/src/main/java/com/rudderstack/models/Message.kt
+++ b/models/src/main/java/com/rudderstack/models/Message.kt
@@ -26,7 +26,6 @@ import java.util.Locale
 import java.util.UUID
 
 typealias MessageContext = Map<String, Any?>
-typealias PageProperties = Map<String, Any>
 typealias ScreenProperties = Map<String, Any>
 typealias TrackProperties = Map<String, Any>
 typealias IdentifyTraits = Map<String, Any?>
@@ -119,7 +118,7 @@ sealed class Message(
     @SerializedName("sentAt")
     @JsonProperty("sentAt")
     @Json(name = "sentAt")
-    var sentAt: String?= null
+    var sentAt: String? = null
     open fun copy(
         context: MessageContext? = this.context,
         anonymousId: String? = this.anonymousId,
@@ -151,17 +150,6 @@ sealed class Message(
             timestamp,
             destinationProps,
             properties,
-        )
-
-        is PageMessage -> copy(
-            context,
-            anonymousId,
-            userId,
-            timestamp,
-            destinationProps,
-            name,
-            properties,
-            category,
         )
 
         is ScreenMessage -> copy(
@@ -198,11 +186,6 @@ sealed class Message(
         @Json(name = "group")
         GROUP("group"),
 
-        @SerializedName("page")
-        @JsonProperty("page")
-        @Json(name = "page")
-        PAGE("page"),
-
         @SerializedName("screen")
         @JsonProperty("screen")
         @Json(name = "screen")
@@ -222,7 +205,6 @@ sealed class Message(
             fun fromValue(value: String) = when (value.lowercase()) {
                 "alias" -> EventType.ALIAS
                 "group" -> EventType.GROUP
-                "page" -> EventType.PAGE
                 "screen" -> EventType.SCREEN
                 "track" -> EventType.TRACK
                 "identify" -> EventType.IDENTIFY
@@ -415,94 +397,6 @@ class GroupMessage internal constructor(
     override fun hashCode(): Int {
         var result = groupId?.hashCode() ?: 0
         result = 31 * result + (traits?.hashCode() ?: 0)
-        return result
-    }
-}
-
-class PageMessage internal constructor(
-
-    @JsonProperty("context") @Json(name = "context") context: MessageContext? = null,
-    @JsonProperty("anonymousId") @Json(name = "anonymousId") anonymousId: String?,
-    @JsonProperty("userId") @Json(name = "userId") userId: String? = null,
-    @JsonProperty("originalTimestamp") @Json(name = "originalTimestamp") timestamp: String,
-
-    @JsonProperty("destinationProps") @Json(name = "destinationProps") destinationProps: MessageDestinationProps? = null,
-    /** @return Name of the event tracked */
-
-    @SerializedName("event") @get:JsonProperty("event") @field:JsonProperty("event") @param:JsonProperty(
-        "event"
-    ) @Json(name = "event") var name: String? = null,
-
-    /**
-     * Get the properties back as set to the event Always convert objects to
-     * it's json equivalent before setting it as values
-     *
-     * @return Map of String-Object
-     */
-
-    @SerializedName("properties") @JsonProperty("properties") @Json(name = "properties") val properties: PageProperties? = null,
-
-    @SerializedName("category") @JsonProperty("category") @Json(name = "category") val category: String? = null,
-    @JsonProperty("not_applicable", required = false) // work-around to ignore value param
-    // jackson serialisation
-    _messageId: String? = null,
-) : Message(
-    EventType.PAGE,
-    context,
-    anonymousId,
-    userId,
-    timestamp,
-    destinationProps,
-    _messageId,
-) {
-    companion object {
-        @JvmStatic
-        fun create(
-            anonymousId: String? = null,
-            userId: String? = null,
-            timestamp: String,
-            destinationProps: MessageDestinationProps? = null,
-            name: String? = null,
-            properties: PageProperties? = null,
-            category: String? = null,
-            traits: Map<String, Any?>? = null,
-            externalIds: List<Map<String, String>>? = null,
-            customContextMap: Map<String, Any>? = null,
-            _messageId: String? = null,
-        ) = PageMessage(
-            createContext(traits, externalIds, customContextMap),
-            anonymousId, userId, timestamp, destinationProps, name, properties,
-            category, _messageId,
-        )
-    }
-
-    fun copy(
-        context: MessageContext? = this.context,
-        anonymousId: String? = this.anonymousId,
-        userId: String? = this.userId,
-        timestamp: String = this.timestamp,
-        destinationProps: MessageDestinationProps? = this.destinationProps,
-        name: String? = this.name,
-        properties: PageProperties? = this.properties,
-        category: String? = this.category,
-
-        ) = PageMessage(
-        context, anonymousId, userId, timestamp, destinationProps, name, properties,
-        category, _messageId = this.messageId,
-    )
-
-    override fun toString(): String {
-        return "${super.toString()}, " + "name = $name, " + "properties = $properties, " + "category = $category"
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return super.equals(other) && other is PageMessage && other.name == name && other.properties == properties && other.category == category
-    }
-
-    override fun hashCode(): Int {
-        var result = name?.hashCode() ?: 0
-        result = 31 * result + (properties?.hashCode() ?: 0)
-        result = 31 * result + (category?.hashCode() ?: 0)
         return result
     }
 }
@@ -782,8 +676,6 @@ class IdentifyMessage internal constructor(
 
 fun TrackProperties(vararg keyPropertyPair: Pair<String, Any>): TrackProperties =
     mapOf(*keyPropertyPair)
-
-// fun PageProperties(vararg keyPropertyPair: Pair<String, Any>) : PageProperties = mapOf(*keyPropertyPair)
 
 fun ScreenProperties(vararg keyPropertyPair: Pair<String, Any>): ScreenProperties =
     mapOf(*keyPropertyPair)

--- a/models/src/test/java/com/rudderstack/models/MessageParseTest.kt
+++ b/models/src/test/java/com/rudderstack/models/MessageParseTest.kt
@@ -32,7 +32,72 @@ abstract class MessageParseTest {
     companion object {
         private const val TRACK_JSON =
             "{\n" +
-                "  \"type\": \"track\",\n" +
+                    "  \"type\": \"track\",\n" +
+                    "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
+                    "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
+                    "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
+                    "  \"userId\": \"debanjanchatterjee\",\n" +
+                    "  \"context\": null,\n" +
+
+                    "  \"integrations\": {\n" +
+                    "    \n" +
+                    "  },\n" +
+                    "  \"event\": \"Java Test\",\n" +
+                    "  \"properties\": {\n" +
+                    "    \"count\": \"1\"\n" +
+                    "  }\n" +
+                    "}"
+        private const val ALIAS_JSON = "{\n" +
+                "  \"type\": \"alias\",\n" +
+                "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
+                "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
+                "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
+                "  \"userId\": \"debanjanchatterjee\",\n" +
+                "  \"context\": null,\n" +
+
+                "  \"integrations\": {\n" +
+                "    \n" +
+                "  },\n" +
+                "  \"previousId\": \"172d84b9-a684-4249-8646-0994173555cd\"\n" +
+                "}"
+
+        private const val GROUP_JSON = "{\n" +
+                "  \"type\": \"group\",\n" +
+                "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
+                "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
+                "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
+                "  \"userId\": \"debanjanchatterjee\",\n" +
+                "  \"context\": null,\n" +
+
+                "  \"integrations\": {\n" +
+                "    \n" +
+                "  },\n" +
+                "  \"groupId\": \"193d84b9-a684-4249-8646-0994173555cd\",\n" +
+                "  \"traits\": {\n" +
+                "    \"group\": \"some_name\",\n" +
+                "    \"journey\": \"Australia\"\n" +
+                "  }\n" +
+                "}"
+        private const val SCREEN_JSON = "{\n" +
+                "  \"type\": \"screen\",\n" +
+                "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
+                "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
+                "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
+                "  \"userId\": \"debanjanchatterjee\",\n" +
+                "  \"context\": null,\n" +
+
+                "  \"integrations\": {\n" +
+                "    \n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "  \"category\": \"login\",\n" +
+                "  \"name\": \"first_screen\",\n" +
+                "    \"count\": \"1\"\n" +
+                "  }\n" +
+                "}"
+
+        private const val PAGE_JSON = "{\n" +
+                "  \"type\": \"page\",\n" +
                 "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
                 "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
                 "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
@@ -45,88 +110,23 @@ abstract class MessageParseTest {
                 "  \"event\": \"Java Test\",\n" +
                 "  \"properties\": {\n" +
                 "    \"count\": \"1\"\n" +
-                "  }\n" +
+                "  },\n" +
+                "  \"category\": \"some_category\"\n" +
                 "}"
-        private const val ALIAS_JSON = "{\n" +
-            "  \"type\": \"alias\",\n" +
-            "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
-            "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
-            "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
-            "  \"userId\": \"debanjanchatterjee\",\n" +
-            "  \"context\": null,\n" +
-
-            "  \"integrations\": {\n" +
-            "    \n" +
-            "  },\n" +
-            "  \"previousId\": \"172d84b9-a684-4249-8646-0994173555cd\"\n" +
-            "}"
-
-        private const val GROUP_JSON = "{\n" +
-            "  \"type\": \"group\",\n" +
-            "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
-            "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
-            "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
-            "  \"userId\": \"debanjanchatterjee\",\n" +
-            "  \"context\": null,\n" +
-
-            "  \"integrations\": {\n" +
-            "    \n" +
-            "  },\n" +
-            "  \"groupId\": \"193d84b9-a684-4249-8646-0994173555cd\",\n" +
-            "  \"traits\": {\n" +
-            "    \"group\": \"some_name\",\n" +
-            "    \"journey\": \"Australia\"\n" +
-            "  }\n" +
-            "}"
-        private const val SCREEN_JSON = "{\n" +
-            "  \"type\": \"screen\",\n" +
-            "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
-            "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
-            "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
-            "  \"userId\": \"debanjanchatterjee\",\n" +
-            "  \"context\": null,\n" +
-
-            "  \"integrations\": {\n" +
-            "    \n" +
-            "  },\n" +
-            "  \"properties\": {\n" +
-            "  \"category\": \"login\",\n" +
-            "  \"name\": \"first_screen\",\n" +
-            "    \"count\": \"1\"\n" +
-            "  }\n" +
-            "}"
-
-        private const val PAGE_JSON = "{\n" +
-            "  \"type\": \"page\",\n" +
-            "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
-            "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
-            "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
-            "  \"userId\": \"debanjanchatterjee\",\n" +
-            "  \"context\": null,\n" +
-
-            "  \"integrations\": {\n" +
-            "    \n" +
-            "  },\n" +
-            "  \"event\": \"Java Test\",\n" +
-            "  \"properties\": {\n" +
-            "    \"count\": \"1\"\n" +
-            "  },\n" +
-            "  \"category\": \"some_category\"\n" +
-            "}"
         private const val IDENTIFY_JSON = "{\n" +
-            "  \"type\": \"identify\",\n" +
-            "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
-            "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
-            "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
-            "  \"userId\": \"debanjanchatterjee\",\n" +
-            "  \"context\": null,\n" +
+                "  \"type\": \"identify\",\n" +
+                "  \"messageId\": \"172d84b9-a684-4249-8646-0994173555cc\",\n" +
+                "  \"originalTimestamp\": \"2021-11-20T15:37:19.753Z\",\n" +
+                "  \"anonymousId\": \"bc73bb87-8fb4-4498-97c8-570299a4686d\",\n" +
+                "  \"userId\": \"debanjanchatterjee\",\n" +
+                "  \"context\": null,\n" +
 
-            "  \"integrations\": {\n" +
-            "    \"firebase\": true,\n" +
-            "    \"amplitude\": false\n" +
-            "  },\n" +
-            "\"properties\": {}\n" +
-            "}"
+                "  \"integrations\": {\n" +
+                "    \"firebase\": true,\n" +
+                "    \"amplitude\": false\n" +
+                "  },\n" +
+                "\"properties\": {}\n" +
+                "}"
     }
 
     @Test
@@ -227,8 +227,12 @@ abstract class MessageParseTest {
                 hasProperty("type", `is`(Message.EventType.SCREEN)),
                 hasProperty("channel", `is`("server")),
                 hasProperty("timestamp", `is`("2021-11-20T15:37:19.753Z")),
-                hasProperty("properties", allOf(aMapWithSize<String, String>(3), hasEntry
-                    ("category", "login"), hasEntry("name", "first_screen")),
+                hasProperty(
+                    "properties",
+                    allOf(
+                        aMapWithSize<String, String>(3), hasEntry
+                            ("category", "login"), hasEntry("name", "first_screen")
+                    ),
                 ),
                 hasProperty("userId", `is`("debanjanchatterjee")),
             ),
@@ -239,32 +243,6 @@ abstract class MessageParseTest {
         JSONAssert.assertEquals(
             screenJson,
             JSONObject(SCREEN_JSON).also {
-                it.put("channel", "server")
-            },
-            JSONCompareMode.LENIENT,
-        )
-    }
-
-    @Test
-    fun testPageParsing() {
-        val page = jsonAdapter.readJson(PAGE_JSON, PageMessage::class.java)
-        assertThat(
-            page,
-            allOf(
-                notNullValue(),
-                hasProperty("type", `is`(Message.EventType.PAGE)),
-                hasProperty("channel", `is`("server")),
-                hasProperty("timestamp", `is`("2021-11-20T15:37:19.753Z")),
-                hasProperty("properties", allOf(aMapWithSize<String, String>(1))),
-                hasProperty("userId", `is`("debanjanchatterjee")),
-                hasProperty("category", `is`("some_category")),
-            ),
-        )
-        assertThat(page!!.properties!!["count"], `is`("1"))
-        val pageJson = jsonAdapter.writeToJson(page)
-        JSONAssert.assertEquals(
-            pageJson,
-            JSONObject(PAGE_JSON).also {
                 it.put("channel", "server")
             },
             JSONCompareMode.LENIENT,


### PR DESCRIPTION
### [Ticket](https://linear.app/rudderstack/issue/SDK-1766/fix-remove-page-event-type-from-messageentity)

## Description 
In this PR, we remove the page event public API from the Android SDK. Page is not supported in the mobile SDKs.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Implementation Details
- Removes the code that relates with the page event
- Removes the relevant tests


## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation