### PR TITLE
feat: add a configurable setting to put the CloudModeProcessor to sleep for a specified interval

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/Constants.java
@@ -48,6 +48,8 @@ class Constants {
     static final boolean COLLECT_DEVICE_ID = true;
     // default residency server
     static final RudderDataResidencyServer DATA_RESIDENCY_SERVER = RudderDataResidencyServer.US;
+    // default for event dispatch sleep interval
+    static final long EVENT_DISPATCH_SLEEP_INTERVAL = 1; // 1 second
 
 
     class Logs {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderConfig.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderConfig.java
@@ -210,7 +210,7 @@ public class RudderConfig {
             this.dbEncryption = dbEncryption;
         }
 
-        if (eventDispatchSleepInterval <= this.sleepTimeOut) {
+        if (eventDispatchSleepInterval <= this.sleepTimeOut && eventDispatchSleepInterval >= Utils.MIN_SLEEP_TIMEOUT) {
             this.eventDispatchSleepInterval = eventDispatchSleepInterval;
         } else {
             this.eventDispatchSleepInterval = Constants.EVENT_DISPATCH_SLEEP_INTERVAL;

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderConfig.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderConfig.java
@@ -60,6 +60,7 @@ public class RudderConfig {
 
     private DBEncryption dbEncryption = new DBEncryption(Constants.DEFAULT_DB_ENCRYPTION_ENABLED,
             null);
+    private long eventDispatchSleepInterval;
 
 
     RudderConfig() {
@@ -87,7 +88,8 @@ public class RudderConfig {
                 Constants.DATA_RESIDENCY_SERVER,
                 null,
                 Constants.DEFAULT_GZIP_ENABLED,
-                null
+                null,
+                Constants.EVENT_DISPATCH_SLEEP_INTERVAL
         );
     }
 
@@ -115,8 +117,8 @@ public class RudderConfig {
             RudderDataResidencyServer rudderDataResidencyServer,
             @Nullable RudderConsentFilter consentFilter,
             boolean isGzipEnabled,
-            @Nullable DBEncryption dbEncryption
-
+            @Nullable DBEncryption dbEncryption,
+            long eventDispatchSleepInterval
 
     ) {
         RudderLogger.init(logLevel);
@@ -206,6 +208,12 @@ public class RudderConfig {
         this.isGzipEnabled = isGzipEnabled;
         if (dbEncryption != null) {
             this.dbEncryption = dbEncryption;
+        }
+
+        if (eventDispatchSleepInterval <= this.sleepTimeOut) {
+            this.eventDispatchSleepInterval = eventDispatchSleepInterval;
+        } else {
+            this.eventDispatchSleepInterval = Constants.EVENT_DISPATCH_SLEEP_INTERVAL;
         }
     }
 
@@ -381,6 +389,17 @@ public class RudderConfig {
         return sessionTimeout;
     }
 
+    /**
+     * Retrieves the event dispatch sleep interval in milliseconds.
+     * Converts the stored interval value (in seconds) to milliseconds
+     * and returns it.
+     *
+     * @return the event dispatch sleep interval in milliseconds
+     */
+    public long getEventDispatchSleepInterval() {
+        return eventDispatchSleepInterval * 1000;
+    }
+
     @Nullable
     public RudderConsentFilter getConsentFilter() {
         return consentFilter;
@@ -453,6 +472,10 @@ public class RudderConfig {
         this.rudderDataResidencyServer = rudderDataResidencyServer;
     }
 
+    void setEventDispatchSleepInterval(long eventDispatchSleepInterval) {
+        this.eventDispatchSleepInterval = eventDispatchSleepInterval;
+    }
+
     /**
      * @return custom toString implementation for RudderConfig
      */
@@ -473,6 +496,7 @@ public class RudderConfig {
         private @Nullable String dataPlaneUrl = null;
         private boolean isGzipEnabled = Constants.DEFAULT_GZIP_ENABLED;
         private @Nullable DBEncryption dbEncryption = null;
+        private long eventDispatchSleepInterval = Constants.EVENT_DISPATCH_SLEEP_INTERVAL;
 
         /**
          * @param factory : Instance of RudderIntegration.Factory (for more information visit https://docs.rudderstack.com)
@@ -809,6 +833,20 @@ public class RudderConfig {
         }
 
         /**
+         * Sets the sleep interval for the event dispatch thread.
+         * This interval (in seconds) determines how long the thread
+         * will sleep when there are no events to send to the server.
+         * The interval must be less than or equal to the value set by withSleepCount(int sleepCount).
+         *
+         * @param eventDispatchSleepInterval the sleep interval in seconds
+         * @return the updated Builder instance for chaining
+         */
+        public Builder withEventDispatchSleepInterval(int eventDispatchSleepInterval) {
+            this.eventDispatchSleepInterval = eventDispatchSleepInterval;
+            return this;
+        }
+
+        /**
          * Finalize your config building
          *
          * @return RudderConfig
@@ -838,7 +876,8 @@ public class RudderConfig {
                     this.rudderDataResidencyServer,
                     consentFilter,
                     this.isGzipEnabled,
-                    this.dbEncryption
+                    this.dbEncryption,
+                    this.eventDispatchSleepInterval
             );
         }
     }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -10,6 +10,7 @@ import android.net.ParseException;
 import android.net.Uri;
 import android.os.BadParcelableException;
 import android.os.Build;
+import android.os.SystemClock;
 import android.text.TextUtils;
 
 import com.google.gson.reflect.TypeToken;
@@ -62,6 +63,14 @@ public class Utils {
 
     public static Long getCurrentTimeInSecondsLong() {
         return new Long(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
+    }
+
+    public static long getUpTimeInMillis() {
+        return SystemClock.uptimeMillis();
+    }
+
+    public static long getSleepDurationInSecond(long startTime, long endTime) {
+        return (endTime - startTime)/1000;
     }
 
     public static String getCurrentTimeSeconds() {

--- a/sample-kotlin/src/main/java/com/rudderstack/android/sample/kotlin/MainApplication.kt
+++ b/sample-kotlin/src/main/java/com/rudderstack/android/sample/kotlin/MainApplication.kt
@@ -36,9 +36,10 @@ class MainApplication : Application(), Configuration.Provider {
                 .withNewLifecycleEvents(true)
                 .withRecordScreenViews(false)
                 .withDbEncryption(RudderConfig.DBEncryption(false, "xyz"))
+                .withSleepCount(6)
+                .withEventDispatchSleepInterval(2)
                 .build()
         )
-
     }
 
 


### PR DESCRIPTION
## Description

Added a builder method `withEventDispatchSleepInterval(int eventDispatchSleepInterval)` that allows users to configure the sleep interval for the `CloudModeProcessor` when it is idle (i.e., no events to process). The default interval is `1 second`, ensuring no change in existing behaviour. This feature enables users to conserve battery by putting the `CloudModeProcessor` thread to sleep for a specified interval.

Also, note that the value specified in `withEventDispatchSleepInterval(...)` should not exceed the `sleepTimeOut` value; otherwise, the default value of 1 second will be used.

**NOTE**: Currently, the default behaviour dictates that if there are no events to process, the `CloudModeProcessor` checks every `1 second` for new events in the database. This ensures prompt event delivery. Once the user changes this default setting, the thread will sleep for a specified interval before checking the database again for new events.

**Fixes** # (*issue*)
https://github.com/rudderlabs/rudder-sdk-android/issues/417

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
