### PR TITLE
fix: remove arguments from the public events apis which are not required

### DIFF
--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -85,22 +85,14 @@ class Analytics private constructor(
     @JvmOverloads
     fun track(
         eventName: String,
-        options: RudderOption? = null,
-        userId: String? = null,
-        anonymousId: String? = null,
         trackProperties: TrackProperties? = null,
-        traits: Map<String, Any?>? = null,
-        destinationProps: MessageDestinationProps? = null,
+        options: RudderOption? = null,
     ) {
         track(
             TrackMessage.create(
-                anonymousId = anonymousId,
-                traits = traits,
-                destinationProps = destinationProps,
-                timestamp = RudderUtils.timeStamp,
                 eventName = eventName,
                 properties = trackProperties,
-                userId = userId
+                timestamp = RudderUtils.timeStamp,
             ), options
         )
     }

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -195,19 +195,14 @@ class Analytics private constructor(
     @JvmOverloads
     fun alias(
         newId: String,
-        anonymousId: String? = null,
         options: RudderOption? = null,
-        destinationProps: MessageDestinationProps? = null,
-        previousId: String? = null,
     ) {
         val completeTraits = mapOf("userId" to newId)
         alias(
             AliasMessage.create(
+                userId = newId,
+                traits = completeTraits,
                 timestamp = RudderUtils.timeStamp,
-                anonymousId = anonymousId,
-                previousId = previousId,
-                destinationProps = destinationProps,
-                userId = newId, traits = completeTraits
             ),
             options
         )

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -7,10 +7,8 @@ import com.rudderstack.core.models.AliasMessage
 import com.rudderstack.core.models.GroupMessage
 import com.rudderstack.core.models.GroupTraits
 import com.rudderstack.core.models.IdentifyMessage
-import com.rudderstack.core.models.IdentifyProperties
 import com.rudderstack.core.models.IdentifyTraits
 import com.rudderstack.core.models.MessageContext
-import com.rudderstack.core.models.MessageDestinationProps
 import com.rudderstack.core.models.ScreenMessage
 import com.rudderstack.core.models.ScreenProperties
 import com.rudderstack.core.models.TrackMessage

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -143,23 +143,15 @@ class Analytics private constructor(
     fun screen(
         screenName: String,
         category: String? = null,
-        options: RudderOption? = null,
         screenProperties: ScreenProperties,
-        anonymousId: String? = null,
-        userId: String? = null,
-        destinationProps: MessageDestinationProps? = null,
-        traits: Map<String, Any?>? = null,
+        options: RudderOption? = null,
     ) {
         screen(
             ScreenMessage.create(
-                userId = userId,
-                anonymousId = anonymousId,
-                destinationProps = destinationProps,
-                traits = traits,
-                timestamp = RudderUtils.timeStamp,
-                category = category,
                 name = screenName,
-                properties = screenProperties
+                category = category,
+                properties = screenProperties,
+                timestamp = RudderUtils.timeStamp,
             ), options
         )
     }

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -221,20 +221,14 @@ class Analytics private constructor(
     @JvmOverloads
     fun group(
         groupId: String?,
-        options: RudderOption? = null,
-        userId: String? = null,
-        anonymousId: String? = null,
         groupTraits: GroupTraits?,
-        destinationProps: MessageDestinationProps? = null,
+        options: RudderOption? = null,
     ) {
         group(
             GroupMessage.create(
-                timestamp = RudderUtils.timeStamp,
-                userId = userId,
                 groupId = groupId,
                 groupTraits = groupTraits,
-                anonymousId = anonymousId,
-                destinationProps = destinationProps,
+                timestamp = RudderUtils.timeStamp,
             ), options
         )
     }

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -168,21 +168,16 @@ class Analytics private constructor(
 
     @JvmOverloads
     fun identify(
-        userId: String, traits: IdentifyTraits? = null,
-        anonymousId: String? = null,
+        userId: String,
+        traits: IdentifyTraits? = null,
         options: RudderOption? = null,
-        properties: IdentifyProperties? = null,
-        destinationProps: MessageDestinationProps? = null,
     ) {
         val completeTraits = mapOf("userId" to userId) optAdd traits
         identify(
             IdentifyMessage.create(
                 userId = userId,
-                anonymousId = anonymousId,
-                destinationProps = destinationProps,
-                timestamp = RudderUtils.timeStamp,
                 traits = completeTraits,
-                properties = properties,
+                timestamp = RudderUtils.timeStamp,
             ), options
         )
     }

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -98,33 +98,24 @@ class Analytics private constructor(
     /**
      * DSL format for track call
      *
+     * ```kotlin
      * analytics.track {
-     *   event { +"event" }
-     *   //or event("event")
-     *   trackProperties {
-     *       //use any of these
-     *       +("property1" to "value1")
-     *       +mapOf("property2" to "value2")
-     *       add("property3" to "value3")
-     *       add(mapOf("property4" to "value4"))
-     *  }
-     *  userId("user_id")
-     *  rudderOptions {
-     *       customContexts {
-     *          +("cc1" to "cp1")
-     *          +("cc2" to "cp2")
-     *       }
-     *       externalIds {
-     *          +(mapOf("ext-1" to "ex1"))
-     *          +(mapOf("ext-2" to "ex2"))
-     *          +listOf(mapOf("ext-3" to "ex3"))
-     *       }
-     *       integrations {
-     *          +("firebase" to true)
-     *          +("amplitude" to false)
-     *       }
-     *    }
+     *     event { +"event" }
+     *     // or event("event")
+     *     trackProperties {
+     *         // use any of these
+     *         +("property1" to "value1")
+     *         +mapOf("property2" to "value2")
+     *         add("property3" to "value3")
+     *         add(mapOf("property4" to "value4"))
+     *     }
+     *     rudderOptions {
+     *         customContexts("cc1", mapOf("cc_1_1" to "ccv"))
+     *         integration("firebase", true)
+     *     }
      * }
+     * ```
+     *
      * @param scope
      */
     fun track(scope: TrackScope.() -> Unit) {

--- a/core/src/main/java/com/rudderstack/core/Analytics.kt
+++ b/core/src/main/java/com/rudderstack/core/Analytics.kt
@@ -44,15 +44,19 @@ class Analytics private constructor(
         shutdownHook: (Analytics.() -> Unit)? = null
     ) : this(
         _delegate = AnalyticsDelegate(
-            configuration, storage ?: BasicStorageImpl(), writeKey, dataUploadService ?: DataUploadServiceImpl(
+            configuration = configuration,
+            storage = storage ?: BasicStorageImpl(),
+            writeKey = writeKey,
+            dataUploadService = dataUploadService ?: DataUploadServiceImpl(
                 writeKey
-            ), configDownloadService ?: ConfigDownloadServiceImpl(
+            ),
+            configDownloadService = configDownloadService ?: ConfigDownloadServiceImpl(
                 writeKey
-            ), initializationListener, shutdownHook
-
+            ),
+            initializationListener = initializationListener,
+            shutdownHook = shutdownHook,
         )
     )
-
 
     companion object {
         // default base url or rudder-backend-server
@@ -99,7 +103,6 @@ class Analytics private constructor(
                 userId = userId
             ), options
         )
-
     }
 
     /**
@@ -267,5 +270,4 @@ class Analytics private constructor(
         groupScope.scope()
         group(groupScope.message, groupScope.options)
     }
-
 }

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -124,11 +124,11 @@ class AliasScope internal constructor() : MessageScope<AliasMessage>() {
 
 class GroupScope internal constructor() : MessageScope<GroupMessage>() {
     private var groupId: String? = null
-    private var groupTraits: GroupTraits? = null
-    fun groupTraits(scope: MapScope<String, Any>.() -> Unit) {
-        val groupScope = MapScope(groupTraits)
+    private var traits: GroupTraits? = null
+    fun traits(scope: MapScope<String, Any>.() -> Unit) {
+        val groupScope = MapScope(traits)
         groupScope.scope()
-        groupTraits = groupScope.map
+        traits = groupScope.map
     }
 
     fun groupId(scope: StringScope.() -> Unit) {
@@ -145,7 +145,7 @@ class GroupScope internal constructor() : MessageScope<GroupMessage>() {
         get() = GroupMessage.create(
             timestamp = RudderUtils.timeStamp,
             groupId = groupId,
-            groupTraits = groupTraits,
+            groupTraits = traits,
         )
 }
 

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -7,129 +7,150 @@ import com.rudderstack.core.models.TrackProperties
 import com.rudderstack.core.models.*
 
 class TrackScope internal constructor() : MessageScope<TrackMessage>() {
-    private var eventName : String? = null
+    private var eventName: String? = null
     private var properties: TrackProperties? = null
     private var traits: Map<String, Any?>? = null
 
-    fun trackProperties(scope: MapScope<String,Any>.() -> Unit){
+    fun trackProperties(scope: MapScope<String, Any>.() -> Unit) {
         val propertiesScope = MapScope(properties)
         propertiesScope.scope()
         properties = propertiesScope.map
     }
-    fun event(scope: StringScope.() -> Unit){
+
+    fun event(scope: StringScope.() -> Unit) {
         val eventScope = StringScope()
         eventScope.scope()
         eventName = eventScope.value
     }
-    fun event(name: String){
+
+    fun event(name: String) {
         eventName = name
     }
 
-    fun traits(scope: MapScope<String,Any?>.() -> Unit){
+    fun traits(scope: MapScope<String, Any?>.() -> Unit) {
         val traitsScope = MapScope(traits)
         traitsScope.scope()
         traits = traitsScope.map
     }
-    override val message: TrackMessage
-        get() = TrackMessage.create(eventName?: throw IllegalArgumentException("No event name for track"),
-        RudderUtils.timeStamp, properties, userId = userId, destinationProps = destinationProperties)
 
+    override val message: TrackMessage
+        get() = TrackMessage.create(
+            eventName ?: throw IllegalArgumentException("No event name for track"),
+            RudderUtils.timeStamp,
+            properties,
+            userId = userId,
+            destinationProps = destinationProperties
+        )
 }
+
 class ScreenScope internal constructor() : MessageScope<ScreenMessage>() {
-    private var screenName : String? = null
-    private var category : String? = null
+    private var screenName: String? = null
+    private var category: String? = null
     private var screenProperties: TrackProperties? = null
 
-    fun screenProperties(scope: MapScope<String,Any>.() -> Unit){
+    fun screenProperties(scope: MapScope<String, Any>.() -> Unit) {
         val propertiesScope = MapScope(screenProperties)
         propertiesScope.scope()
         screenProperties = propertiesScope.map
     }
-    fun screenName(scope: StringScope.() -> Unit){
+
+    fun screenName(scope: StringScope.() -> Unit) {
         val eventScope = StringScope()
         eventScope.scope()
         screenName = eventScope.value
     }
-    fun screenName(name: String){
+
+    fun screenName(name: String) {
         screenName = name
     }
-    fun category(scope: StringScope.() -> Unit){
+
+    fun category(scope: StringScope.() -> Unit) {
         val eventScope = StringScope()
         eventScope.scope()
         category = eventScope.value
     }
-    fun category(name: String){
+
+    fun category(name: String) {
         category = name
     }
-    override val message: ScreenMessage
-        get() = ScreenMessage.create(screenName ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
-                RudderUtils.timeStamp, category = category,
-            anonymousId = anonymousId,
-        properties = screenProperties, userId = userId, destinationProps = destinationProperties)
 
+    override val message: ScreenMessage
+        get() = ScreenMessage.create(
+            screenName
+                ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
+            RudderUtils.timeStamp, category = category,
+            anonymousId = anonymousId,
+            properties = screenProperties, userId = userId, destinationProps = destinationProperties
+        )
 }
+
 class IdentifyScope internal constructor() : MessageScope<IdentifyMessage>() {
     private var traits: IdentifyTraits? = null
     private var userID: String? = null
 
-    fun traits(scope: MapScope<String,Any?>.() -> Unit){
+    fun traits(scope: MapScope<String, Any?>.() -> Unit) {
         val traitsScope = MapScope(traits)
         traitsScope.scope()
         traits = traitsScope.map
     }
+
     override val message: IdentifyMessage
         get() = IdentifyMessage.create(
             userId = userID,
             anonymousId = anonymousId,
             timestamp = RudderUtils.timeStamp,
             traits = traits,
-         destinationProps = destinationProperties)
-
+            destinationProps = destinationProperties
+        )
 }
+
 class AliasScope internal constructor() : MessageScope<AliasMessage>() {
     private var newID: String? = null
 
     private var traits: Map<String, Any?>? = null
 
-    fun newId(scope: StringScope.() -> Unit){
+    fun newId(scope: StringScope.() -> Unit) {
         val titleScope = StringScope()
         titleScope.scope()
         newID = titleScope.value
     }
-    fun newId(newId : String){
+
+    fun newId(newId: String) {
         newID = newId
     }
 
-    fun traits(scope: MapScope<String,Any?>.() -> Unit){
+    fun traits(scope: MapScope<String, Any?>.() -> Unit) {
         val traitsScope = MapScope(traits)
         traitsScope.scope()
         traits = traitsScope.map
     }
 
     override val message: AliasMessage
-        get() = AliasMessage.create(timestamp = RudderUtils.timeStamp, userId = newID,
+        get() = AliasMessage.create(
+            timestamp = RudderUtils.timeStamp, userId = newID,
             anonymousId = anonymousId,
-            previousId = userId?:anonymousId, traits = traits, destinationProps =
-    destinationProperties,
-         )
-
+            previousId = userId ?: anonymousId, traits = traits,
+            destinationProps =
+            destinationProperties,
+        )
 }
+
 class GroupScope internal constructor() : MessageScope<GroupMessage>() {
-    private var groupId : String? = null
+    private var groupId: String? = null
     private var traits: GroupTraits? = null
-    fun traits(scope: MapScope<String,Any>.() -> Unit){
+    fun traits(scope: MapScope<String, Any>.() -> Unit) {
         val groupScope = MapScope(traits)
         groupScope.scope()
         traits = groupScope.map
     }
 
-
-    fun groupId(scope: StringScope.() -> Unit){
+    fun groupId(scope: StringScope.() -> Unit) {
         val groupScope = StringScope()
         groupScope.scope()
         groupId = groupScope.value
     }
-    fun groupId(id: String){
+
+    fun groupId(id: String) {
         groupId = id
     }
 
@@ -137,9 +158,8 @@ class GroupScope internal constructor() : MessageScope<GroupMessage>() {
         get() = GroupMessage.create(
             timestamp = RudderUtils.timeStamp, userId = userId,
             anonymousId = anonymousId,
-            groupId = groupId, groupTraits = traits
-            , destinationProps = destinationProperties)
-
+            groupId = groupId, groupTraits = traits, destinationProps = destinationProperties
+        )
 }
 
 @MessageScopeDslMarker
@@ -150,7 +170,7 @@ abstract class MessageScope<T : Message> internal constructor(/*private val anal
 
     private var _destinationProperties: MessageDestinationProps? = null
     protected val destinationProperties
-    get() = _destinationProperties
+        get() = _destinationProperties
     protected var anonymousId: String? = null
     protected var userId: String? = null
     fun rudderOptions(scope: RudderOptionsScope.() -> Unit) {
@@ -159,52 +179,54 @@ abstract class MessageScope<T : Message> internal constructor(/*private val anal
         _options = optionsScope.rudderOption
     }
 
-    fun destinationProperties(scope: MapScope<String, Map<*, *>>.() -> Unit){
+    fun destinationProperties(scope: MapScope<String, Map<*, *>>.() -> Unit) {
         val destinationPropsScope = MapScope(_destinationProperties)
         destinationPropsScope.scope()
         _destinationProperties = destinationPropsScope.map
     }
-    fun userId(scope: StringScope.() -> Unit){
+
+    fun userId(scope: StringScope.() -> Unit) {
         val titleScope = StringScope()
         titleScope.scope()
         userId = titleScope.value
     }
-    fun userId(userId : String){
+
+    fun userId(userId: String) {
         this.userId = userId
     }
-    fun anonymousId(scope: StringScope.() -> Unit){
+
+    fun anonymousId(scope: StringScope.() -> Unit) {
         val anonymousIdScope = StringScope()
         anonymousIdScope.scope()
         anonymousId = anonymousIdScope.value
     }
-    fun anonymousId(id: String){
+
+    fun anonymousId(id: String) {
         anonymousId = id
     }
-    internal abstract val message: T
-    /*internal fun send(){
-        analytics.processMessage(message, options)
-    }*/
 
+    internal abstract val message: T
 }
 
-class StringScope internal constructor(){
-    private var _value : String? = null
+class StringScope internal constructor() {
+    private var _value: String? = null
     val value
-    get() = _value
+        get() = _value
 
-    operator fun String.unaryPlus(){
+    operator fun String.unaryPlus() {
         _value = this
     }
 }
+
 @OptionsScopeDslMarker
 class RudderOptionsScope internal constructor() {
-
     //    private var rudderOptionsBuilder: RudderOptions.Builder = RudderOptions.Builder()
     internal val rudderOption: RudderOption
         get() = _rudderOption
     private val _rudderOption: RudderOption by lazy {
         RudderOption()
     }
+
     fun externalId(type: String, id: String) {
         _rudderOption.putExternalId(type, id)
     }
@@ -220,8 +242,6 @@ class RudderOptionsScope internal constructor() {
     fun customContexts(key: String, context: Map<String?, Any?>) {
         _rudderOption.putCustomContext(key, context)
     }
-
-
 }
 
 class CollectionsScope<E>
@@ -267,7 +287,6 @@ internal constructor(private var _map: Map<K, V>?) {
     internal val map
         get() = _map
 }
-
 
 @DslMarker
 annotation class MessageScopeDslMarker

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -2,7 +2,6 @@ package com.rudderstack.core
 
 import com.rudderstack.core.models.GroupTraits
 import com.rudderstack.core.models.IdentifyTraits
-import com.rudderstack.core.models.MessageDestinationProps
 import com.rudderstack.core.models.TrackProperties
 import com.rudderstack.core.models.*
 
@@ -39,7 +38,6 @@ class TrackScope internal constructor() : MessageScope<TrackMessage>() {
             RudderUtils.timeStamp,
             properties,
             userId = userId,
-            destinationProps = destinationProperties
         )
 }
 
@@ -80,7 +78,7 @@ class ScreenScope internal constructor() : MessageScope<ScreenMessage>() {
                 ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
             RudderUtils.timeStamp, category = category,
             anonymousId = anonymousId,
-            properties = screenProperties, userId = userId, destinationProps = destinationProperties
+            properties = screenProperties, userId = userId,
         )
 }
 
@@ -100,7 +98,6 @@ class IdentifyScope internal constructor() : MessageScope<IdentifyMessage>() {
             anonymousId = anonymousId,
             timestamp = RudderUtils.timeStamp,
             traits = traits,
-            destinationProps = destinationProperties
         )
 }
 
@@ -130,8 +127,6 @@ class AliasScope internal constructor() : MessageScope<AliasMessage>() {
             timestamp = RudderUtils.timeStamp, userId = newID,
             anonymousId = anonymousId,
             previousId = userId ?: anonymousId, traits = traits,
-            destinationProps =
-            destinationProperties,
         )
 }
 
@@ -158,7 +153,7 @@ class GroupScope internal constructor() : MessageScope<GroupMessage>() {
         get() = GroupMessage.create(
             timestamp = RudderUtils.timeStamp, userId = userId,
             anonymousId = anonymousId,
-            groupId = groupId, groupTraits = traits, destinationProps = destinationProperties
+            groupId = groupId, groupTraits = traits,
         )
 }
 
@@ -168,21 +163,12 @@ abstract class MessageScope<T : Message> internal constructor(/*private val anal
     internal val options
         get() = _options
 
-    private var _destinationProperties: MessageDestinationProps? = null
-    protected val destinationProperties
-        get() = _destinationProperties
     protected var anonymousId: String? = null
     protected var userId: String? = null
     fun rudderOptions(scope: RudderOptionsScope.() -> Unit) {
         val optionsScope = RudderOptionsScope()
         optionsScope.scope()
         _options = optionsScope.rudderOption
-    }
-
-    fun destinationProperties(scope: MapScope<String, Map<*, *>>.() -> Unit) {
-        val destinationPropsScope = MapScope(_destinationProperties)
-        destinationPropsScope.scope()
-        _destinationProperties = destinationPropsScope.map
     }
 
     fun userId(scope: StringScope.() -> Unit) {

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -106,8 +106,6 @@ class IdentifyScope internal constructor() : MessageScope<IdentifyMessage>() {
 class AliasScope internal constructor() : MessageScope<AliasMessage>() {
     private var newID: String? = null
 
-    private var traits: Map<String, Any?>? = null
-
     fun newId(scope: StringScope.() -> Unit) {
         val titleScope = StringScope()
         titleScope.scope()
@@ -118,18 +116,10 @@ class AliasScope internal constructor() : MessageScope<AliasMessage>() {
         newID = newId
     }
 
-    fun traits(scope: MapScope<String, Any?>.() -> Unit) {
-        val traitsScope = MapScope(traits)
-        traitsScope.scope()
-        traits = traitsScope.map
-    }
-
     override val message: AliasMessage
         get() = AliasMessage.create(
             timestamp = RudderUtils.timeStamp,
             userId = newID,
-            anonymousId = anonymousId,
-            traits = traits,
         )
 }
 

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -8,7 +8,6 @@ import com.rudderstack.core.models.*
 class TrackScope internal constructor() : MessageScope<TrackMessage>() {
     private var eventName: String? = null
     private var properties: TrackProperties? = null
-    private var traits: Map<String, Any?>? = null
 
     fun trackProperties(scope: MapScope<String, Any>.() -> Unit) {
         val propertiesScope = MapScope(properties)
@@ -26,18 +25,11 @@ class TrackScope internal constructor() : MessageScope<TrackMessage>() {
         eventName = name
     }
 
-    fun traits(scope: MapScope<String, Any?>.() -> Unit) {
-        val traitsScope = MapScope(traits)
-        traitsScope.scope()
-        traits = traitsScope.map
-    }
-
     override val message: TrackMessage
         get() = TrackMessage.create(
-            eventName ?: throw IllegalArgumentException("No event name for track"),
-            RudderUtils.timeStamp,
-            properties,
-            userId = userId,
+            eventName = eventName ?: throw IllegalArgumentException("No event name for track"),
+            timestamp = RudderUtils.timeStamp,
+            properties = properties,
         )
 }
 

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -97,7 +97,6 @@ class IdentifyScope internal constructor() : MessageScope<IdentifyMessage>() {
     override val message: IdentifyMessage
         get() = IdentifyMessage.create(
             userId = userId,
-            anonymousId = anonymousId,
             timestamp = RudderUtils.timeStamp,
             traits = traits,
         )
@@ -155,22 +154,11 @@ abstract class MessageScope<T : Message> internal constructor(/*private val anal
     private var _options: RudderOption? = null
     internal val options
         get() = _options
-    protected var anonymousId: String? = null
 
     fun rudderOptions(scope: RudderOptionsScope.() -> Unit) {
         val optionsScope = RudderOptionsScope()
         optionsScope.scope()
         _options = optionsScope.rudderOption
-    }
-
-    fun anonymousId(scope: StringScope.() -> Unit) {
-        val anonymousIdScope = StringScope()
-        anonymousIdScope.scope()
-        anonymousId = anonymousIdScope.value
-    }
-
-    fun anonymousId(id: String) {
-        anonymousId = id
     }
 
     internal abstract val message: T
@@ -258,9 +246,6 @@ internal constructor(private var _map: Map<K, V>?) {
 
 @DslMarker
 annotation class MessageScopeDslMarker
-
-@DslMarker
-annotation class PropertyScopeDslMarker
 
 @DslMarker
 annotation class OptionsScopeDslMarker

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -125,11 +125,11 @@ class AliasScope internal constructor() : MessageScope<AliasMessage>() {
 
 class GroupScope internal constructor() : MessageScope<GroupMessage>() {
     private var groupId: String? = null
-    private var traits: GroupTraits? = null
-    fun traits(scope: MapScope<String, Any>.() -> Unit) {
-        val groupScope = MapScope(traits)
+    private var groupTraits: GroupTraits? = null
+    fun groupTraits(scope: MapScope<String, Any>.() -> Unit) {
+        val groupScope = MapScope(groupTraits)
         groupScope.scope()
-        traits = groupScope.map
+        groupTraits = groupScope.map
     }
 
     fun groupId(scope: StringScope.() -> Unit) {
@@ -145,9 +145,8 @@ class GroupScope internal constructor() : MessageScope<GroupMessage>() {
     override val message: GroupMessage
         get() = GroupMessage.create(
             timestamp = RudderUtils.timeStamp,
-            anonymousId = anonymousId,
             groupId = groupId,
-            groupTraits = traits,
+            groupTraits = groupTraits,
         )
 }
 

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -66,7 +66,8 @@ class ScreenScope internal constructor() : MessageScope<ScreenMessage>() {
 
     override val message: ScreenMessage
         get() = ScreenMessage.create(
-            name = screenName ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
+            name = screenName
+                ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
             timestamp = RudderUtils.timeStamp,
             category = category,
             properties = screenProperties
@@ -75,7 +76,17 @@ class ScreenScope internal constructor() : MessageScope<ScreenMessage>() {
 
 class IdentifyScope internal constructor() : MessageScope<IdentifyMessage>() {
     private var traits: IdentifyTraits? = null
-    private var userID: String? = null
+    private var userId: String? = null
+
+    fun userId(scope: StringScope.() -> Unit) {
+        val titleScope = StringScope()
+        titleScope.scope()
+        this.userId = titleScope.value
+    }
+
+    fun userId(userId: String) {
+        this.userId = userId
+    }
 
     fun traits(scope: MapScope<String, Any?>.() -> Unit) {
         val traitsScope = MapScope(traits)
@@ -85,7 +96,7 @@ class IdentifyScope internal constructor() : MessageScope<IdentifyMessage>() {
 
     override val message: IdentifyMessage
         get() = IdentifyMessage.create(
-            userId = userID,
+            userId = userId,
             anonymousId = anonymousId,
             timestamp = RudderUtils.timeStamp,
             traits = traits,
@@ -115,9 +126,10 @@ class AliasScope internal constructor() : MessageScope<AliasMessage>() {
 
     override val message: AliasMessage
         get() = AliasMessage.create(
-            timestamp = RudderUtils.timeStamp, userId = newID,
+            timestamp = RudderUtils.timeStamp,
+            userId = newID,
             anonymousId = anonymousId,
-            previousId = userId ?: anonymousId, traits = traits,
+            traits = traits,
         )
 }
 
@@ -142,9 +154,10 @@ class GroupScope internal constructor() : MessageScope<GroupMessage>() {
 
     override val message: GroupMessage
         get() = GroupMessage.create(
-            timestamp = RudderUtils.timeStamp, userId = userId,
+            timestamp = RudderUtils.timeStamp,
             anonymousId = anonymousId,
-            groupId = groupId, groupTraits = traits,
+            groupId = groupId,
+            groupTraits = traits,
         )
 }
 
@@ -153,23 +166,12 @@ abstract class MessageScope<T : Message> internal constructor(/*private val anal
     private var _options: RudderOption? = null
     internal val options
         get() = _options
-
     protected var anonymousId: String? = null
-    protected var userId: String? = null
+
     fun rudderOptions(scope: RudderOptionsScope.() -> Unit) {
         val optionsScope = RudderOptionsScope()
         optionsScope.scope()
         _options = optionsScope.rudderOption
-    }
-
-    fun userId(scope: StringScope.() -> Unit) {
-        val titleScope = StringScope()
-        titleScope.scope()
-        userId = titleScope.value
-    }
-
-    fun userId(userId: String) {
-        this.userId = userId
     }
 
     fun anonymousId(scope: StringScope.() -> Unit) {

--- a/core/src/main/java/com/rudderstack/core/Dsl.kt
+++ b/core/src/main/java/com/rudderstack/core/Dsl.kt
@@ -66,11 +66,10 @@ class ScreenScope internal constructor() : MessageScope<ScreenMessage>() {
 
     override val message: ScreenMessage
         get() = ScreenMessage.create(
-            screenName
-                ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
-            RudderUtils.timeStamp, category = category,
-            anonymousId = anonymousId,
-            properties = screenProperties, userId = userId,
+            name = screenName ?: throw IllegalArgumentException("Screen name is not provided for screen event"),
+            timestamp = RudderUtils.timeStamp,
+            category = category,
+            properties = screenProperties
         )
 }
 

--- a/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
+++ b/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
@@ -318,14 +318,12 @@ abstract class AnalyticsTest {
         val chainCaptor = argumentCaptor<Plugin.Chain>()
         analytics.track(
             eventName = "track",
-            userId = "user_id",
             trackProperties = mapOf("prop-1" to "p-1", "prop-2" to "p-2")
         )
         busyWait(100)//since it is submitted to executor
 
         verify(laterInitDestPlugin).intercept(chainCaptor.capture())
         val message = chainCaptor.firstValue.message()
-        assertThat(message.userId, `is`("user_id"))
         assertThat(
             message, hasProperty(
                 "properties", allOf(

--- a/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
+++ b/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
@@ -248,7 +248,6 @@ abstract class AnalyticsTest {
         analytics = generateTestAnalytics(Configuration(jsonAdapter))
         analytics.track {
             event("event-1")
-            userId("user_id")
             trackProperties {
                 add("prop-1" to "p-1")
                 add("prop-2" to "p-2")
@@ -261,7 +260,6 @@ abstract class AnalyticsTest {
                 output, allOf(
                     notNullValue(),
                     instanceOf(TrackMessage::class.java),
-                    hasProperty("userId", `is`("user_id")),
                     hasProperty(
                         "properties", allOf(
                             aMapWithSize<String, Any>(3),
@@ -281,7 +279,6 @@ abstract class AnalyticsTest {
         analytics.shutdown()
         analytics = generateTestAnalytics(Configuration(jsonAdapter))
         analytics.alias {
-            userId("user_id")
             newId("new_id")
         }
         analytics.assertArgument { input, output ->
@@ -291,7 +288,6 @@ abstract class AnalyticsTest {
                     notNullValue(),
                     instanceOf(AliasMessage::class.java),
                     hasProperty("userId", `is`("new_id")),
-                    hasProperty("previousId", `is`("user_id")),
                 )
             )
         }
@@ -810,7 +806,6 @@ abstract class AnalyticsTest {
                 add("property3" to "value3")
                 add(mapOf("property4" to "value4"))
             }
-            userId("user_id")
             rudderOptions {
                 customContexts("cc1", mapOf("cc_1_1" to "ccv"))
                 customContexts("cc2", mapOf("cc_2_1" to "ccv2"))

--- a/samples/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/main.kt
+++ b/samples/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/main.kt
@@ -101,6 +101,5 @@ fun makeAllEventsDirectlyUsingAndroidCompatibleEventsAPI() {
 
     analytics.alias(
         newId = "New Alias UserID",
-        previousId = "Old Alias UserID",
     )
 }

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/mainview/MainViewModel.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/mainview/MainViewModel.kt
@@ -68,9 +68,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     eventName = "Track at ${Date()}",
                     trackProperties = TrackProperties("key1" to "prop1", "key2" to "prop2"),
                     options = RudderOption().putIntegration("firebase", false)
-                        .putExternalId(
-                            "fb_id","1234"
-                        )
                 )
                 "Track message sent"
             }
@@ -79,7 +76,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 RudderAnalyticsUtils.analytics.identify(
                     userId = "some_user_id", traits = IdentifyTraits("trait1" to "some_trait"),
                     options = RudderOption().putExternalId("test_ext_id_key_$extCount", "test_val_$extCount")
-
                 )
                 ++ extCount
                 "Identify called"


### PR DESCRIPTION
## Description

- Removed unused arguments (like userId) from public events APIs (like Track) which are not required and also they are not in parity with v1.
- Removed unused arguments from event DSL class e.g., removed traits field from TrackScope class.
- Fixed indentation.
- Fixed failing test cases.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
