### PR TITLE
refactor: in plugins setup analytics method

### DIFF
--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/AnonymousIdHeaderPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/AnonymousIdHeaderPlugin.kt
@@ -1,17 +1,3 @@
-/*
- * Creator: Debanjan Chatterjee on 29/11/23, 4:58 pm Last modified: 29/11/23, 4:58 pm
- * Copyright: All rights reserved Ⓒ 2023 http://rudderstack.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License. You may obtain a
- * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package com.rudderstack.android.internal.infrastructure
 
 import com.rudderstack.android.AndroidUtils
@@ -22,26 +8,30 @@ import com.rudderstack.core.Configuration
 import com.rudderstack.core.DataUploadService
 import com.rudderstack.core.InfrastructurePlugin
 
-internal class AnonymousIdHeaderPlugin : InfrastructurePlugin{
+internal class AnonymousIdHeaderPlugin : InfrastructurePlugin {
+
+    override lateinit var analytics: Analytics
     private var dataUploadService: DataUploadService? = null
-    private var _analytics: Analytics? = null
+
     override fun setup(analytics: Analytics) {
-        _analytics = analytics
+        super.setup(analytics)
         dataUploadService = analytics.dataUploadService
+    }
+
+    override fun updateConfiguration(configuration: Configuration) {
+        if (configuration !is ConfigurationAndroid) return
+        val anonId = configuration.anonymousId ?: AndroidUtils.generateAnonymousId(
+            configuration.collectDeviceId,
+            configuration.application
+        ).also {
+            analytics.applyConfigurationAndroid {
+                copy(anonymousId = it)
+            }
+        }
+        dataUploadService?.addHeaders(mapOf("Anonymous-Id" to anonId))
     }
 
     override fun shutdown() {
         dataUploadService = null
-        _analytics = null
-    }
-
-    override fun updateConfiguration(configuration: Configuration) {
-        if(configuration !is ConfigurationAndroid) return
-        val anonId = configuration.anonymousId?: AndroidUtils.generateAnonymousId(configuration.collectDeviceId, configuration.application).also {
-                _analytics?.applyConfigurationAndroid {
-                    copy(anonymousId = it)
-                }
-        }
-            dataUploadService?.addHeaders(mapOf("Anonymous-Id" to anonId))
     }
 }

--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/ResetImplementationPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/ResetImplementationPlugin.kt
@@ -8,21 +8,18 @@ import com.rudderstack.core.models.createContext
 import com.rudderstack.core.models.updateWith
 
 class ResetImplementationPlugin : InfrastructurePlugin {
-    private var _analytics: Analytics? = null
-    override fun setup(analytics: Analytics) {
-        _analytics = analytics
-    }
+
+    override lateinit var analytics: Analytics
+
     private val contextState
-    get() =_analytics?.contextState
+        get() = analytics.contextState
+
     override fun reset() {
-
-        _analytics?.processNewContext(contextState?.value?.updateWith(traits = mapOf(),
-            externalIds = listOf()
-        ) ?: createContext())
+        analytics.processNewContext(
+            contextState?.value?.updateWith(
+                traits = mapOf(),
+                externalIds = listOf()
+            ) ?: createContext()
+        )
     }
-
-    override fun shutdown() {
-        //nothing to implement
-    }
-
 }

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/SessionPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/SessionPlugin.kt
@@ -3,6 +3,7 @@ package com.rudderstack.android.internal.plugins
 import com.rudderstack.android.ConfigurationAndroid
 import com.rudderstack.android.internal.extensions.withSessionId
 import com.rudderstack.android.internal.extensions.withSessionStart
+import com.rudderstack.android.models.UserSession
 import com.rudderstack.android.utilities.defaultLastActiveTimestamp
 import com.rudderstack.android.utilities.resetSession
 import com.rudderstack.android.utilities.startSessionIfNeeded
@@ -12,35 +13,33 @@ import com.rudderstack.core.Analytics
 import com.rudderstack.core.Configuration
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.models.Message
-import com.rudderstack.android.models.UserSession
 
 internal class SessionPlugin : Plugin {
 
-    private var _analytics: Analytics? = null
+    override lateinit var analytics: Analytics
+
     private var currentConfiguration: ConfigurationAndroid? = null
-    override fun setup(analytics: Analytics) {
-        super.setup(analytics)
-        _analytics = analytics
-    }
 
     override fun updateConfiguration(configuration: Configuration) {
         if (configuration !is ConfigurationAndroid) return
         if (currentConfiguration?.trackAutoSession == configuration.trackAutoSession
-            && currentConfiguration?.trackLifecycleEvents == configuration.trackLifecycleEvents) return
-        if( !configuration.trackAutoSession || !configuration.trackLifecycleEvents) {
-            _analytics?.updateSessionEnd()
+            && currentConfiguration?.trackLifecycleEvents == configuration.trackLifecycleEvents
+        ) return
+        if (!configuration.trackAutoSession || !configuration.trackLifecycleEvents) {
+            analytics.updateSessionEnd()
             return
         }
-        _analytics?.startSessionIfNeeded()
+        analytics.startSessionIfNeeded()
     }
+
 
     override fun intercept(chain: Plugin.Chain): Message {
         //apply session id and session start
         // update last active timestamp
         // if difference between two events is more than session timeout, refresh session
         val message = chain.message()
-        _analytics?.startSessionIfNeeded()
-        val newMsg = _analytics?.userSessionState?.value?.takeIf { it.isActive }?.let {
+        analytics.startSessionIfNeeded()
+        val newMsg = analytics.userSessionState?.value?.takeIf { it.isActive }?.let {
             updateWithSession(message, it)
         } ?: message
 
@@ -62,12 +61,12 @@ internal class SessionPlugin : Plugin {
         val updatedSession = it.copy(
             lastActiveTimestamp = defaultLastActiveTimestamp, sessionStart = false
         )
-        _analytics?.userSessionState?.update(updatedSession)
+        analytics.userSessionState?.update(updatedSession)
     }
 
 
     override fun reset() {
-        _analytics?.resetSession()
+        analytics.resetSession()
     }
 
 }

--- a/core/src/main/java/com/rudderstack/core/BasicStorageImpl.kt
+++ b/core/src/main/java/com/rudderstack/core/BasicStorageImpl.kt
@@ -3,9 +3,16 @@ package com.rudderstack.core
 import com.rudderstack.core.models.IdentifyTraits
 import com.rudderstack.core.models.Message
 import com.rudderstack.core.models.RudderServerConfig
-import java.io.*
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.LinkedList
+import java.util.Properties
+import java.util.Queue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicReference
 
@@ -22,6 +29,8 @@ class BasicStorageImpl @JvmOverloads constructor(
      */
     private val queue: Queue<Message> = LinkedBlockingQueue(),
 ) : Storage {
+
+    override lateinit var analytics: Analytics
     private var configurationRef = AtomicReference<Configuration>(null)
 
     private val logger
@@ -259,10 +268,6 @@ class BasicStorageImpl @JvmOverloads constructor(
     override val libraryOsVersion: String
         get() = libDetails[LIB_KEY_OS_VERSION] ?: ""
 
-    override fun setup(analytics: Analytics) {
-        //no-op
-    }
-
     override fun updateConfiguration(configuration: Configuration) {
         configurationRef.set(configuration)
     }
@@ -278,7 +283,5 @@ class BasicStorageImpl @JvmOverloads constructor(
             }
 
         }
-
     }
-
 }

--- a/core/src/main/java/com/rudderstack/core/DestinationPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/DestinationPlugin.kt
@@ -60,7 +60,7 @@ interface DestinationPlugin<T> : Plugin {
      * These plugins only act on the main-plugin that it is added to.
      *
      */
-    fun interface DestinationInterceptor : Plugin
+    interface DestinationInterceptor : Plugin
 
     /**
      * Called when flush is triggered.
@@ -128,6 +128,7 @@ abstract class BaseDestinationPlugin<T>(override val name: String) : Destination
             crossinline block: (chain: Plugin.Chain) -> Message
         ): BaseDestinationPlugin<T> =
             object : BaseDestinationPlugin<T>(name) {
+                override lateinit var analytics: Analytics
                 override fun intercept(chain: Plugin.Chain): Message {
                     return block(chain)
                 }

--- a/core/src/main/java/com/rudderstack/core/InfrastructurePlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/InfrastructurePlugin.kt
@@ -9,8 +9,14 @@ import com.rudderstack.core.models.RudderServerConfig
  *
  */
 interface InfrastructurePlugin {
-    fun setup(analytics: Analytics)
-    fun shutdown()
+
+    var analytics: Analytics
+
+    fun setup(analytics: Analytics) {
+        this.analytics = analytics
+    }
+
+    fun shutdown() {}
     fun updateConfiguration(configuration: Configuration) {
         //optional method
     }

--- a/core/src/main/java/com/rudderstack/core/Plugin.kt
+++ b/core/src/main/java/com/rudderstack/core/Plugin.kt
@@ -8,7 +8,14 @@ import com.rudderstack.core.models.RudderServerConfig
  * responses coming back in. Typically plugins transforms or logs the data sent over to destinations.
  *
  */
-fun interface Plugin {
+interface Plugin {
+
+    var analytics: Analytics
+
+    fun setup(analytics: Analytics) {
+        this.analytics = analytics
+    }
+
     /**
      * Joins ("chains") the plugins for a particular message
      *
@@ -84,13 +91,6 @@ fun interface Plugin {
     fun intercept(chain: Chain): Message
 
     /**
-     * Setup code for this plugin
-     * Helps in changing settings, etc.
-     * @param analytics The analytics object this plugin is added to.
-     */
-    fun setup(analytics: Analytics) {}
-
-    /**
      * Called when settings is updated
      *
      * @param configuration [Configuration] globally set for the sdk
@@ -110,6 +110,4 @@ fun interface Plugin {
      *
      */
     fun reset() {}
-
-
 }

--- a/core/src/main/java/com/rudderstack/core/compat/BaseDestinationPluginCompat.java
+++ b/core/src/main/java/com/rudderstack/core/compat/BaseDestinationPluginCompat.java
@@ -74,5 +74,15 @@ public abstract class BaseDestinationPluginCompat<T> extends BaseDestinationPlug
         public void reset() {
         }
 
+        @NotNull
+        @Override
+        public Analytics getAnalytics() {
+            return null; //we will figure this out later
+        }
+
+        @Override
+        public void setAnalytics(@NotNull Analytics analytics) {
+
+        }
     }
 }

--- a/core/src/main/java/com/rudderstack/core/flushpolicy/FlushPolicy.kt
+++ b/core/src/main/java/com/rudderstack/core/flushpolicy/FlushPolicy.kt
@@ -20,6 +20,5 @@ import com.rudderstack.core.InfrastructurePlugin
 interface FlushPolicy : InfrastructurePlugin {
     fun reschedule()
     fun onRemoved()
-
     fun setFlush(flush: Analytics.() -> Unit)
 }

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/CoreInputsPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/CoreInputsPlugin.kt
@@ -10,23 +10,18 @@ private const val LIBRARY_KEY = "library"
 /**
  * Plugin to add the library details to context object of payload.
  */
-class CoreInputsPlugin : Plugin{
+class CoreInputsPlugin : Plugin {
+    override lateinit var analytics: Analytics
+
     private val Storage.libraryContextPair
         get() = LIBRARY_KEY to mapOf("name" to libraryName, "version" to libraryVersion)
-    private var storage: Storage?= null
-    override fun setup(analytics: Analytics) {
-        storage = analytics.storage
-    }
+
     override fun intercept(chain: Plugin.Chain): Message {
         val message = chain.message()
-        val context = storage?.let {
-            storage -> message.context?.let { it + storage.libraryContextPair }?: mapOf(storage.libraryContextPair)
-        }?: return chain.proceed(message)
+        val context = analytics.storage.let { storage ->
+            message.context?.let { it + storage.libraryContextPair } ?: mapOf(storage.libraryContextPair)
+        }
         return chain.proceed(message.copy(context = context))
-    }
-
-    override fun onShutDown() {
-        storage = null
     }
 
 }

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/DestinationConfigurationPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/DestinationConfigurationPlugin.kt
@@ -1,5 +1,6 @@
 package com.rudderstack.core.internal.plugins
 
+import com.rudderstack.core.Analytics
 import com.rudderstack.core.DestinationPlugin
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.models.Message
@@ -18,7 +19,9 @@ import com.rudderstack.core.models.RudderServerConfig
  * plugins that are disabled in destination config are filtered out.
  */
 internal class DestinationConfigurationPlugin : Plugin {
-    private var _notAllowedDestinations : Set<String> = setOf()
+    override lateinit var analytics: Analytics
+
+    private var _notAllowedDestinations: Set<String> = setOf()
     private var _isConfigUpdated = false
     override fun intercept(chain: Plugin.Chain): Message {
         val msg = chain.message()
@@ -26,7 +29,7 @@ internal class DestinationConfigurationPlugin : Plugin {
             //either not a destination plugin or is allowed
             it !is DestinationPlugin<*> || (_isConfigUpdated && it.name !in _notAllowedDestinations)
         }
-        return  if (validPlugins.isNotEmpty()) {
+        return if (validPlugins.isNotEmpty()) {
             return chain.with(validPlugins).proceed(msg)
         } else
             chain.proceed(msg)
@@ -37,7 +40,7 @@ internal class DestinationConfigurationPlugin : Plugin {
         _notAllowedDestinations = config.source?.destinations?.filter {
             !it.isDestinationEnabled
         }?.map {
-            it.destinationDefinition?.definitionName?:it.destinationName?: ""
-        }?.toHashSet()?: setOf()
+            it.destinationDefinition?.definitionName ?: it.destinationName ?: ""
+        }?.toHashSet() ?: setOf()
     }
 }

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/EventFilteringPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/EventFilteringPlugin.kt
@@ -1,5 +1,6 @@
 package com.rudderstack.core.internal.plugins
 
+import com.rudderstack.core.Analytics
 import com.rudderstack.core.DestinationPlugin
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.models.Message
@@ -17,8 +18,10 @@ private const val WHITELISTED_EVENTS = "whitelistedEvents"
 private const val BLACKLISTED_EVENTS = "blacklistedEvents"
 private const val EVENT_FILTERING_OPTION = "eventFilteringOption"
 private const val EVENT_NAME = "eventName"
+
 class EventFilteringPlugin : Plugin {
 
+    override lateinit var analytics: Analytics
 
     //map of (destination definition name, DestinationEventFilteringConfig)
     private var filteredEventsMap = ConcurrentHashMap<String, DestinationEventFilteringConfig>()

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/EventSizeFilterPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/EventSizeFilterPlugin.kt
@@ -1,5 +1,6 @@
 package com.rudderstack.core.internal.plugins
 
+import com.rudderstack.core.Analytics
 import com.rudderstack.core.Configuration
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderUtils.MAX_EVENT_SIZE
@@ -12,6 +13,8 @@ import java.util.concurrent.atomic.AtomicReference
  * A plugin to filter out events that exceed the maximum size limit.
  */
 class EventSizeFilterPlugin : Plugin {
+    
+    override lateinit var analytics: Analytics
 
     private val currentConfigurationAtomic = AtomicReference<Configuration?>()
     private val currentConfiguration

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/GDPRPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/GDPRPlugin.kt
@@ -10,18 +10,13 @@ import com.rudderstack.core.models.Message
  */
 internal class GDPRPlugin : Plugin {
 
-    private var _analytics: Analytics? = null
+    override lateinit var analytics: Analytics
+
     override fun intercept(chain: Plugin.Chain): Message {
-        val isOptOut = _analytics?.storage?.isOptedOut ?: false
-        return if (isOptOut) {
+        return if (analytics.storage.isOptedOut) {
             chain.message()
         } else {
             chain.proceed(chain.message())
         }
-    }
-
-    override fun setup(analytics: Analytics) {
-        super.setup(analytics)
-        _analytics = analytics
     }
 }

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/RudderOptionPlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/RudderOptionPlugin.kt
@@ -1,10 +1,13 @@
 package com.rudderstack.core.internal.plugins
 
-import com.rudderstack.core.models.*
+import com.rudderstack.core.Analytics
 import com.rudderstack.core.DestinationPlugin
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderOption
 import com.rudderstack.core.minusWrtKeys
+import com.rudderstack.core.models.Message
+import com.rudderstack.core.models.MessageContext
+import com.rudderstack.core.models.externalIds
 import com.rudderstack.core.models.updateWith
 
 /**
@@ -21,6 +24,8 @@ import com.rudderstack.core.models.updateWith
  * @param options
  */
 internal class RudderOptionPlugin(private val options: RudderOption) : Plugin {
+
+    override lateinit var analytics: Analytics
 
     override fun intercept(chain: Plugin.Chain): Message {
         val msg = chain.message().let { oldMsg ->
@@ -62,7 +67,6 @@ internal class RudderOptionPlugin(private val options: RudderOption) : Plugin {
 
     private fun validIntegrations(): Map<String, Boolean> {
         return options.integrations.ifEmpty { mapOf("All" to true) }
-
     }
 
     private fun Message.updateContext(options: RudderOption): MessageContext? {

--- a/core/src/main/java/com/rudderstack/core/internal/plugins/StoragePlugin.kt
+++ b/core/src/main/java/com/rudderstack/core/internal/plugins/StoragePlugin.kt
@@ -3,7 +3,6 @@ package com.rudderstack.core.internal.plugins
 import com.rudderstack.core.Analytics
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.models.Message
-import java.lang.ref.WeakReference
 
 /**
  * Adds [Message] to repository for further processing.
@@ -12,19 +11,13 @@ import java.lang.ref.WeakReference
  *
  */
 internal class StoragePlugin : Plugin {
-    private var _analytics: WeakReference<Analytics?> = WeakReference(null)
-    override fun setup(analytics: Analytics) {
-        _analytics = WeakReference(analytics)
-    }
+
+    override lateinit var analytics: Analytics
 
     override fun intercept(chain: Plugin.Chain): Message {
         val message = chain.message()
-        _analytics.get()?.storage?.saveMessage(message.copy())
-
+        analytics.storage.saveMessage(message.copy())
         return chain.proceed(message)
     }
 
-    override fun onShutDown() {
-        _analytics = WeakReference(null)
-    }
 }

--- a/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
+++ b/core/src/test/java/com/rudderstack/core/AnalyticsTest.kt
@@ -521,20 +521,21 @@ abstract class AnalyticsTest {
         }
         val isDone = AtomicBoolean(false)
         var msgCounter = 1
-        val assertionPlugin = Plugin {
-            val msg = it.message()
-            assertThat(
-                msg, allOf(
-                    Matchers.isA(TrackMessage::class.java),
-                    hasProperty("eventName", `is`("event:${msgCounter++}"))
+        val assertPlugin = object : Plugin {
+            override lateinit var analytics: Analytics
+            override fun intercept(chain: Plugin.Chain): Message {
+                assertThat(
+                    chain.message(), allOf(
+                        Matchers.isA(TrackMessage::class.java),
+                        hasProperty("eventName", `is`("event:${msgCounter++}"))
+                    )
                 )
-            )
-            Thread.sleep(20L) //a minor delay
-            if (events.size < msgCounter) isDone.set(true)
-            it.proceed(it.message())
+                Thread.sleep(20L) //a minor delay
+                if (events.size < msgCounter) isDone.set(true)
+                return chain.proceed(chain.message())
+            }
         }
-
-        analytics.addPlugin(assertionPlugin)
+        analytics.addPlugin(assertPlugin)
         for (i in events) {
             analytics.track(i)
         }
@@ -784,11 +785,15 @@ abstract class AnalyticsTest {
     fun `test custom plugin`() {
         println("running test test custom plugin")
         val isDone = AtomicBoolean(false)
-        val customPlugin = Plugin {
-            println("inside custom plugin")
-            isDone.set(true)
-            it.proceed(it.message())
+        val customPlugin = object : Plugin {
+            override lateinit var analytics: Analytics
+            override fun intercept(chain: Plugin.Chain): Message {
+                println("inside custom plugin")
+                isDone.set(true)
+                return chain.proceed(chain.message())
+            }
         }
+
         val waitUntil = AtomicBoolean(false)
         analytics.addCallback(object : Callback {
             override fun success(message: Message?) {

--- a/core/src/test/java/com/rudderstack/core/internal/plugins/CoreInputsPluginTest.kt
+++ b/core/src/test/java/com/rudderstack/core/internal/plugins/CoreInputsPluginTest.kt
@@ -43,25 +43,6 @@ class CoreInputsPluginTest {
     }
 
     @Test
-    fun `intercept method proceeds without modification when storage is null`() {
-        // Arrange
-        val mockChain = mock<Plugin.Chain>()
-        val mockMessage = TrackMessage.create("ev_name", RudderUtils.timeStamp)
-        `when`(mockChain.message()).thenReturn(mockMessage)
-        whenever(mockChain.proceed(any())) doAnswer {
-            it.getArgument(0)
-        }
-
-        // Act
-        val result = coreInputsPlugin.intercept(mockChain)
-
-        // Assert
-        assertThat(result, `is`(mockMessage))
-        verify(mockChain).proceed(mockMessage)
-    }
-
-
-    @Test
     fun `intercept method adds library context to message context when storage is not null`() {
         // Arrange
         val mockChain = mock<Plugin.Chain>()

--- a/core/src/test/java/com/rudderstack/core/internal/plugins/EventSizeFilterPluginTest.kt
+++ b/core/src/test/java/com/rudderstack/core/internal/plugins/EventSizeFilterPluginTest.kt
@@ -1,14 +1,15 @@
 package com.rudderstack.core.internal.plugins
 
+import com.rudderstack.core.Analytics
 import com.rudderstack.core.Configuration
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderUtils
 import com.rudderstack.core.RudderUtils.MAX_EVENT_SIZE
 import com.rudderstack.core.RudderUtils.getUTF8Length
 import com.rudderstack.core.internal.CentralPluginChain
-import com.rudderstack.gsonrudderadapter.GsonAdapter
 import com.rudderstack.core.models.Message
 import com.rudderstack.core.models.TrackMessage
+import com.rudderstack.gsonrudderadapter.GsonAdapter
 import org.junit.Test
 
 class EventSizeFilterPluginTest {
@@ -19,9 +20,12 @@ class EventSizeFilterPluginTest {
     @Test
     fun `given event size does not exceed the maximum size, then the next plugin in the chain should be called`() {
         var isCalled = false
-        val testPlugin = Plugin {
-            isCalled = true
-            it.proceed(it.message())
+        val testPlugin = object : Plugin {
+            override lateinit var analytics: Analytics
+            override fun intercept(chain: Plugin.Chain): Message {
+                isCalled = true
+                return chain.proceed(chain.message())
+            }
         }
         val message = getMessageUnderMaxSize()
         val eventSizeFilterTestChain = CentralPluginChain(
@@ -39,9 +43,12 @@ class EventSizeFilterPluginTest {
     @Test
     fun `given event size exceeds the maximum size, then the next plugin in the chain should not be called`() {
         var isCalled = false
-        val testPlugin = Plugin {
-            isCalled = true
-            it.proceed(it.message())
+        val testPlugin = object : Plugin {
+            override lateinit var analytics: Analytics
+            override fun intercept(chain: Plugin.Chain): Message {
+                isCalled = true
+                return chain.proceed(chain.message())
+            }
         }
         val message = getMessageOverMaxSize()
         val eventSizeFilterTestChain = CentralPluginChain(

--- a/core/src/test/java/com/rudderstack/core/internal/plugins/GDPRPluginTest.kt
+++ b/core/src/test/java/com/rudderstack/core/internal/plugins/GDPRPluginTest.kt
@@ -4,6 +4,7 @@ import com.rudderstack.core.Analytics
 import com.rudderstack.core.Plugin
 import com.rudderstack.core.RudderUtils
 import com.rudderstack.core.internal.CentralPluginChain
+import com.rudderstack.core.models.Message
 import com.rudderstack.core.models.TrackMessage
 import io.mockk.every
 import io.mockk.mockk
@@ -30,10 +31,12 @@ class GDPRPluginTest {
     fun `test gdpr with opt out`() {
         val analytics = mockk<Analytics>(relaxed = true)
         every { analytics.storage.isOptedOut } returns true
-        val testPluginForOptOut = Plugin {
-            //should not be called
-            assert(false)
-            it.proceed(it.message())
+        val testPluginForOptOut = object : Plugin {
+            override lateinit var analytics: Analytics
+            override fun intercept(chain: Plugin.Chain): Message {
+                assert(false)
+                return chain.proceed(chain.message())
+            }
         }
         val optOutTestChain = CentralPluginChain(
             message, listOf(gdprPlugin, testPluginForOptOut), originalMessage = message
@@ -51,11 +54,14 @@ class GDPRPluginTest {
         every { analytics.storage.isOptedOut } returns false
 
         var isCalled = false
-        val testPluginForOptIn = Plugin {
-            //should be called
-            isCalled = true
-            it.proceed(it.message())
+        val testPluginForOptIn = object : Plugin {
+            override lateinit var analytics: Analytics
+            override fun intercept(chain: Plugin.Chain): Message {
+                isCalled = true
+                return chain.proceed(chain.message())
+            }
         }
+
         val optInTestChain = CentralPluginChain(
             message, listOf(gdprPlugin, testPluginForOptIn),
             originalMessage = message

--- a/libs/sync/src/main/java/com/rudderstack/android/sync/WorkerManagerPlugin.kt
+++ b/libs/sync/src/main/java/com/rudderstack/android/sync/WorkerManagerPlugin.kt
@@ -1,30 +1,19 @@
-/*
- * Creator: Debanjan Chatterjee on 23/11/23, 6:20 pm Last modified: 23/11/23, 6:20 pm
- * Copyright: All rights reserved Ⓒ 2023 http://rudderstack.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License. You may obtain a
- * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package com.rudderstack.android.sync
 
 import android.app.Application
-import com.rudderstack.android.utilities.currentConfigurationAndroid
 import com.rudderstack.android.sync.internal.registerWorkManager
 import com.rudderstack.android.sync.internal.unregisterWorkManager
+import com.rudderstack.android.utilities.currentConfigurationAndroid
 import com.rudderstack.core.Analytics
 import com.rudderstack.core.InfrastructurePlugin
 
 abstract class WorkerManagerPlugin : InfrastructurePlugin {
-    private var application: Application?= null
+
+    private var application: Application? = null
     private var analyticsIdentifier: String? = null
+
     override fun setup(analytics: Analytics) {
+        super.setup(analytics)
         analyticsIdentifier = analytics.writeKey
         val currentConfig = analytics.currentConfigurationAndroid
         if (currentConfig?.isPeriodicFlushEnabled != true) {
@@ -40,6 +29,7 @@ abstract class WorkerManagerPlugin : InfrastructurePlugin {
             )
         }
     }
+
     override fun shutdown() {
         application?.unregisterWorkManager(analyticsIdentifier ?: return)
         analyticsIdentifier = null
@@ -52,5 +42,4 @@ abstract class WorkerManagerPlugin : InfrastructurePlugin {
      * with garbage collector
      */
     abstract val workManagerAnalyticsFactoryClassName: Class<out WorkManagerAnalyticsFactory>
-
 }

--- a/libs/test-common/src/main/java/com/vagabond/testcommon/MockConfigDownloadService.kt
+++ b/libs/test-common/src/main/java/com/vagabond/testcommon/MockConfigDownloadService.kt
@@ -12,6 +12,7 @@ class MockConfigDownloadService(
     )
 ) : ConfigDownloadService {
 
+    override lateinit var analytics: Analytics
 
     override fun download(callback: (success: Boolean, RudderServerConfig?, lastErrorMsg: String?) -> Unit) {
         callback(mockConfigDownloadSuccess, mockConfig, mockLastErrorMsg)
@@ -22,10 +23,6 @@ class MockConfigDownloadService(
     }
 
     override fun removeListener(listener: ConfigDownloadService.Listener) {
-        // Not-required
-    }
-
-    override fun setup(analytics: Analytics) {
         // Not-required
     }
 

--- a/libs/test-common/src/main/java/com/vagabond/testcommon/TestAnalyticsProvider.kt
+++ b/libs/test-common/src/main/java/com/vagabond/testcommon/TestAnalyticsProvider.kt
@@ -14,10 +14,13 @@ import com.rudderstack.rudderjsonadapter.JsonAdapter
 private const val DUMMY_WRITE_KEY = "DUMMY_WRITE_KEY"
 private var currentTestPlugin: Plugin? = null
 private var inputs = listOf<Message>()
-val inputVerifyPlugin = Plugin { chain ->
-    chain.proceed(chain.message().also {
-        inputs += it.copy()
-    })
+val inputVerifyPlugin = object : Plugin {
+    override lateinit var analytics: Analytics
+    override fun intercept(chain: Plugin.Chain): Message {
+        return chain.proceed(chain.message().also {
+            inputs += it.copy()
+        })
+    }
 }
 
 fun generateTestAnalytics(jsonAdapter: JsonAdapter): Analytics {

--- a/libs/test-common/src/main/java/com/vagabond/testcommon/TestDataUploadService.kt
+++ b/libs/test-common/src/main/java/com/vagabond/testcommon/TestDataUploadService.kt
@@ -6,11 +6,13 @@ import com.rudderstack.core.models.Message
 import com.rudderstack.web.HttpResponse
 
 class TestDataUploadService : DataUploadService {
+
+    override lateinit var analytics: Analytics
     private var headers = mutableMapOf<String, String>()
 
     var mockUploadStatus = 200
     var mockUploadBody = "OK"
-    var errorBody : String? = null
+    var errorBody: String? = null
     var error: Throwable? = null
     override fun addHeaders(headers: Map<String, String>) {
         this.headers += headers
@@ -29,8 +31,6 @@ class TestDataUploadService : DataUploadService {
     ): HttpResponse<out Any>? {
         return HttpResponse(mockUploadStatus, mockUploadBody, errorBody, error)
     }
-
-    override fun setup(analytics: Analytics) {}
 
     override fun shutdown() {
         headers = mutableMapOf()

--- a/libs/test-common/src/main/java/com/vagabond/testcommon/VerificationStorage.kt
+++ b/libs/test-common/src/main/java/com/vagabond/testcommon/VerificationStorage.kt
@@ -7,6 +7,7 @@ import com.rudderstack.core.models.RudderServerConfig
 
 class VerificationStorage : Storage {
 
+    override lateinit var analytics: Analytics
     private var storageQ = mutableListOf<Message>()
     private var _serverConfig: RudderServerConfig? = null
     override fun setStorageCapacity(storageCapacity: Int) {
@@ -98,9 +99,5 @@ class VerificationStorage : Storage {
         get() = "Android"
     override val libraryOsVersion: String
         get() = "13"
-
-    override fun setup(analytics: Analytics) {
-        /* No-op . */
-    }
 
 }

--- a/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/workmanger/SampleWorkManagerPlugin.kt
+++ b/samples/sample-kotlin-android/src/main/kotlin/com/rudderstack/android/sampleapp/analytics/workmanger/SampleWorkManagerPlugin.kt
@@ -16,8 +16,12 @@ package com.rudderstack.android.sampleapp.analytics.workmanger
 
 import com.rudderstack.android.sync.WorkManagerAnalyticsFactory
 import com.rudderstack.android.sync.WorkerManagerPlugin
+import com.rudderstack.core.Analytics
 
 class SampleWorkManagerPlugin: WorkerManagerPlugin() {
+
+    override lateinit var analytics: Analytics
+
     override val workManagerAnalyticsFactoryClassName: Class<out WorkManagerAnalyticsFactory>
         get() = SampleWorkManagerAnalyticsFactory::class.java
 }


### PR DESCRIPTION
### [Ticket](https://linear.app/rudderstack/issue/SDK-2150/refactor-rudderpreferencemanager-class)

## Description 
In this PR we are refactoring the `Plugin` and `InfrastructuralPlugin` interfaces with a common implementation of the `fun setup(analytics: Analytics)` method. With this refactor, we are avoiding repeating the same method over the plugins again and  again and we are simplifying the creation of a plugin, always providing the `var analytics : Analytics` instance in the implementations. We are also preparing the ground for more refactorings

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

## Implementation Details
- Added `var analytics: Analytics` in the `Plugin` interface
- Added `fun setup(analytics: Analytics)` as an implementation in the `Plugin` interface
- Added `var analytics: Analytics` in the `InfrastructuralPlugin` interface
- Added `fun setup(analytics: Analytics)` as an implementation in the `InfrastructuralPlugin` interface
- Applied changes in the Plugins that are implementing the interfaces
- Changes in the tests so that all pass as before.

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [x] I have made corresponding changes to the documentation

### Screenshots
- All the modules and tests are running as expected. Also, the kotlin sample application is built like normal.
<img src="https://github.com/user-attachments/assets/1de3ee57-c3f1-4c15-a963-d83670e2ca3b" height="400" />
