### PR TITLE
fix: rudder preference manager refactor

### DIFF
--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/AppInstallUpdateTrackerPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/AppInstallUpdateTrackerPlugin.kt
@@ -53,9 +53,7 @@ class AppInstallUpdateTrackerPlugin : Plugin {
         } else {
             DEFAULT_BUILD
         }
-        val previousVersionName: String = if (analytics.androidStorage.versionName.isEmpty()) {
-            analytics.androidStorage.versionName
-        } else {
+        val previousVersionName: String = analytics.androidStorage.versionName.ifEmpty {
             DEFAULT_VERSION_NAME
         }
         var currentBuild: Int? = null

--- a/android/src/main/java/com/rudderstack/android/internal/infrastructure/LifecycleObserverPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/infrastructure/LifecycleObserverPlugin.kt
@@ -59,7 +59,7 @@ internal class LifecycleObserverPlugin(
                         _isFirstLaunch.getAndSet(false).also { isFirstLaunch ->
                             add("from_background" to !isFirstLaunch)
                         }.takeIf { it }?.let {
-                            add("version" to (analytics.androidStorage.versionName ?: ""))
+                            add("version" to (analytics.androidStorage.versionName))
                         }
                     }
                 }

--- a/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/plugins/FillDefaultsPlugin.kt
@@ -61,7 +61,7 @@ internal class FillDefaultsPlugin : Plugin {
         return (this.copy(
             context = newContext,
             anonymousId = anonId,
-            userId = userId
+            userId = userId.ifEmpty { null }
         ) as T)
     }
 

--- a/android/src/main/java/com/rudderstack/android/internal/prefs/SharedPrefsStore.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/prefs/SharedPrefsStore.kt
@@ -15,7 +15,7 @@ class SharedPrefsStore(
     private val preferences: SharedPreferences = applicationContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
 
     override fun getInt(key: String): Int {
-        return preferences.getInt(key, 0)
+        return preferences.getInt(key, -1)
     }
 
     override fun getBoolean(key: String): Boolean {

--- a/android/src/main/java/com/rudderstack/android/internal/prefs/SharedPrefsStore.kt
+++ b/android/src/main/java/com/rudderstack/android/internal/prefs/SharedPrefsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.core.content.edit
+import com.rudderstack.android.utilities.empty
 import java.io.File
 
 class SharedPrefsStore(

--- a/android/src/main/java/com/rudderstack/android/storage/AndroidStorageImpl.kt
+++ b/android/src/main/java/com/rudderstack/android/storage/AndroidStorageImpl.kt
@@ -298,30 +298,51 @@ class AndroidStorageImpl(
         }
     }
 
-    override val startupQueue: List<Message> = startupQ
-    override val optOutTime: Long = _optOutTime.get()
-    override val optInTime: Long = _optInTime.get()
-    override val anonymousId: String = rudderPrefsRepo.getString(RUDDER_ANONYMOUS_ID_KEY)
-    override val userId: String = rudderPrefsRepo.getString(RUDDER_USER_ID_KEY)
-    override val sessionId: Long = rudderPrefsRepo.getLong(RUDDER_SESSION_ID_KEY)
-    override val lastActiveTimestamp: Long = rudderPrefsRepo.getLong(RUDDER_SESSION_LAST_ACTIVE_TIMESTAMP_KEY)
-    override val advertisingId: String = rudderPrefsRepo.getString(RUDDER_ADVERTISING_ID_KEY)
-    override val trackAutoSession: Boolean = rudderPrefsRepo.getBoolean(RUDDER_TRACK_AUTO_SESSION_KEY)
-    override val build: Int = rudderPrefsRepo.getInt(RUDDER_APPLICATION_BUILD_KEY)
-    override val versionName: String = rudderPrefsRepo.getString(RUDDER_APPLICATION_VERSION_KEY)
-    override val isOptedOut: Boolean = rudderPrefsRepo.getBoolean(RUDDER_OPT_STATUS_KEY)
+    override val startupQueue: List<Message>
+        get() = startupQ
+    override val optOutTime: Long
+        get() = _optOutTime.get()
+    override val optInTime: Long
+        get() = _optInTime.get()
+    override val anonymousId: String
+        get() = rudderPrefsRepo.getString(RUDDER_ANONYMOUS_ID_KEY)
+    override val userId: String
+        get() = rudderPrefsRepo.getString(RUDDER_USER_ID_KEY)
+    override val sessionId: Long
+        get() = rudderPrefsRepo.getLong(RUDDER_SESSION_ID_KEY)
+    override val lastActiveTimestamp: Long
+        get() = rudderPrefsRepo.getLong(RUDDER_SESSION_LAST_ACTIVE_TIMESTAMP_KEY)
+    override val advertisingId: String
+        get() = rudderPrefsRepo.getString(RUDDER_ADVERTISING_ID_KEY)
+    override val trackAutoSession: Boolean
+        get() = rudderPrefsRepo.getBoolean(RUDDER_TRACK_AUTO_SESSION_KEY)
+    override val build: Int
+        get() = rudderPrefsRepo.getInt(RUDDER_APPLICATION_BUILD_KEY)
+    override val versionName: String
+        get() = rudderPrefsRepo.getString(RUDDER_APPLICATION_VERSION_KEY)
+    override val isOptedOut: Boolean
+        get() = rudderPrefsRepo.getBoolean(RUDDER_OPT_STATUS_KEY)
 
-    override val v1AnonymousId: String = oldRudderPrefs.getString(RUDDER_ANONYMOUS_ID_KEY)
-    override val v1SessionId: Long = oldRudderPrefs.getLong(RUDDER_SESSION_ID_KEY)
-    override val v1LastActiveTimestamp: Long = oldRudderPrefs.getLong(RUDDER_SESSION_LAST_ACTIVE_TIMESTAMP_KEY)
-    override val v1AdvertisingId: String = oldRudderPrefs.getString(RUDDER_ADVERTISING_ID_KEY)
-    override val v1Build: Int = oldRudderPrefs.getInt(RUDDER_APPLICATION_BUILD_KEY)
-    override val v1VersionName: String = oldRudderPrefs.getString(RUDDER_APPLICATION_VERSION_KEY)
-    override val v1OptOut: Boolean = oldRudderPrefs.getBoolean(RUDDER_OPT_STATUS_KEY)
-    override val v1Traits: Map<String, Any?>? = oldRudderPrefs.getString(RUDDER_TRAITS_KEY).let {
+    override val v1AnonymousId: String
+        get() = oldRudderPrefs.getString(RUDDER_ANONYMOUS_ID_KEY)
+    override val v1SessionId: Long
+        get() = oldRudderPrefs.getLong(RUDDER_SESSION_ID_KEY)
+    override val v1LastActiveTimestamp: Long
+        get() = oldRudderPrefs.getLong(RUDDER_SESSION_LAST_ACTIVE_TIMESTAMP_KEY)
+    override val v1AdvertisingId: String
+        get() = oldRudderPrefs.getString(RUDDER_ADVERTISING_ID_KEY)
+    override val v1Build: Int
+        get() = oldRudderPrefs.getInt(RUDDER_APPLICATION_BUILD_KEY)
+    override val v1VersionName: String
+        get() = oldRudderPrefs.getString(RUDDER_APPLICATION_VERSION_KEY)
+    override val v1OptOut: Boolean
+        get() = oldRudderPrefs.getBoolean(RUDDER_OPT_STATUS_KEY)
+    override val v1Traits: Map<String, Any?>?
+        get() = oldRudderPrefs.getString(RUDDER_TRAITS_KEY).let {
         jsonAdapter?.readJson(it, object : RudderTypeAdapter<Map<String, Any?>>() {})
     }
-    override val v1ExternalIds: List<Map<String, String>>? = oldRudderPrefs.getString(RUDDER_EXTERNAL_ID_KEY).let {
+    override val v1ExternalIds: List<Map<String, String>>?
+        get() = oldRudderPrefs.getString(RUDDER_EXTERNAL_ID_KEY).let {
         jsonAdapter?.readJson(it, object : RudderTypeAdapter<List<Map<String, String>>>() {})
     }
 


### PR DESCRIPTION
## Description

Fixed the following issues:
- UserId was being sent as an empty field. Now, it will not be sent if it is empty.
- Fixed lifecycle logic.
- Modified `getInt` in Shared Preferences to return `-1` when the value is not found.
- Implemented custom getters for all fields in Storage to ensure the latest values are fetched.

**Fixes** # (*issue*)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
