### PR TITLE
feat: implement exponential retry mechanism for handling network errors

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -7,7 +7,9 @@ import static com.rudderstack.android.sdk.core.RudderNetworkManager.Result;
 import static com.rudderstack.android.sdk.core.RudderNetworkManager.addEndPoint;
 
 import com.rudderstack.android.sdk.core.gson.RudderGson;
+import com.rudderstack.android.sdk.core.util.ExponentialBackOff;
 import com.rudderstack.android.sdk.core.util.MessageUploadLock;
+import com.rudderstack.android.sdk.core.util.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,6 +42,7 @@ public class RudderCloudModeManager {
                 Result result = null;
                 final ArrayList<Integer> messageIds = new ArrayList<>();
                 final ArrayList<String> messages = new ArrayList<>();
+                final ExponentialBackOff exponentialBackOff = new ExponentialBackOff(5 * 60); // 5 minutes
                 while (true) {
                     // clear lists for reuse
                     messageIds.clear();
@@ -62,6 +65,7 @@ public class RudderCloudModeManager {
                                     dbManager.markCloudModeDone(messageIds);
                                     dbManager.runGcForEvents();
                                     sleepCount = 0;
+                                    exponentialBackOff.resetBackOff();
                                 } else {
                                     incrementCloudModeUploadRetryCounter(1);
                                 }
@@ -84,9 +88,13 @@ public class RudderCloudModeManager {
                                 deleteEventsWithoutAnonymousId(messages, messageIds);
                                 break;
                             case ERROR:
+                                long sleepIntervalInMillis = exponentialBackOff.nextDelayInMillis();
+                                RudderLogger.logWarn("CloudModeManager: cloudModeProcessor: Retrying in " + Utils.getTimeInReadableFormat(sleepIntervalInMillis));
+                                Thread.sleep(sleepIntervalInMillis);
+                                break;
                             case NETWORK_UNAVAILABLE:
-                                RudderLogger.logWarn("CloudModeManager: cloudModeProcessor: Retrying in " + Math.abs(sleepCount - config.getSleepTimeOut()) + "s");
-                                Thread.sleep(Math.abs(sleepCount - config.getSleepTimeOut()) * 1000L);
+                                RudderLogger.logWarn("CloudModeManager: cloudModeProcessor: Retrying in 1s");
+                                Thread.sleep(1000);
                                 break;
                             default:
                                 RudderLogger.logWarn("CloudModeManager: cloudModeProcessor: Retrying in 1s");

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
@@ -1,5 +1,7 @@
 package com.rudderstack.android.sdk.core.util;
 
+import androidx.annotation.VisibleForTesting;
+
 import java.util.Random;
 
 /**
@@ -7,7 +9,7 @@ import java.util.Random;
  * It allows for configurable maximum delay and includes methods to calculate the next delay
  * with jitter and reset the backoff attempts.
  * When the calculated delay reaches or exceeds the maximum delay limit, the backoff resets
- * and starts again from 1 second.
+ * and starts again from beginning.
  */
 public class ExponentialBackOff {
     private int attempt = 0;
@@ -43,7 +45,8 @@ public class ExponentialBackOff {
         return exponentialIntervalInSecs * 1000;
     }
 
-    private long withJitter(long delayInSecs) {
+    @VisibleForTesting
+    protected long withJitter(long delayInSecs) {
         long jitter = random.nextInt((int) delayInSecs);
         return delayInSecs + jitter;
     }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
@@ -2,7 +2,7 @@ package com.rudderstack.android.sdk.core.util;
 
 import androidx.annotation.VisibleForTesting;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 /**
  * This class implements an exponential backoff strategy with jitter for handling retries.
@@ -14,7 +14,7 @@ import java.util.Random;
 public class ExponentialBackOff {
     private int attempt = 0;
     private final int maxDelayInSecs;
-    private final Random random;
+    private final SecureRandom random;
 
     /**
      * Constructor to initialize the ExponentialBackOff with a maximum delay.
@@ -23,7 +23,7 @@ public class ExponentialBackOff {
      */
     public ExponentialBackOff(int maxDelayInSecs) {
         this.maxDelayInSecs = maxDelayInSecs;
-        this.random = new Random();
+        this.random = new SecureRandom();
     }
 
     /**

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
@@ -1,0 +1,56 @@
+package com.rudderstack.android.sdk.core.util;
+
+import java.util.Random;
+
+/**
+ * This class implements an exponential backoff strategy with jitter for handling retries.
+ * It allows for configurable maximum delay and includes methods to calculate the next delay
+ * with jitter and reset the backoff attempts.
+ * When the calculated delay reaches or exceeds the maximum delay limit, the backoff resets
+ * and starts again from 1 second.
+ */
+public class ExponentialBackOff {
+    private int attempt = 0;
+    private final int maxDelayInSecs;
+    private final Random random;
+
+    /**
+     * Constructor to initialize the ExponentialBackOff with a maximum delay.
+     *
+     * @param maxDelayInSecs Maximum delay in seconds for the backoff.
+     */
+    public ExponentialBackOff(int maxDelayInSecs) {
+        this.maxDelayInSecs = maxDelayInSecs;
+        this.random = new Random();
+    }
+
+    /**
+     * Calculates the next delay with exponential backoff and jitter.
+     *
+     * @return The next delay in milliseconds.
+     */
+    public long nextDelayInMillis() {
+        int base = 2;
+        long delayInSecs = (long) Math.pow(base, attempt++);
+        long exponentialIntervalInSecs = Math.min(maxDelayInSecs, withJitter(delayInSecs));
+
+        // Reset the backoff if the delay reaches or exceeds the maximum limit
+        if (exponentialIntervalInSecs >= maxDelayInSecs) {
+            resetBackOff();
+        }
+
+        return exponentialIntervalInSecs * 1000;
+    }
+
+    private long withJitter(long delayInSecs) {
+        long jitter = random.nextInt((int) delayInSecs);
+        return delayInSecs + jitter;
+    }
+
+    /**
+     * Resets the backoff attempt counter to 0.
+     */
+    public void resetBackOff() {
+        attempt = 0;
+    }
+}

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/ExponentialBackOff.java
@@ -31,7 +31,8 @@ public class ExponentialBackOff {
      */
     public long nextDelayInMillis() {
         int base = 2;
-        long delayInSecs = (long) Math.pow(base, attempt++);
+        int initialDelayInSecs = 3;
+        long delayInSecs = (long) (initialDelayInSecs * Math.pow(base, attempt++));
         long exponentialIntervalInSecs = Math.min(maxDelayInSecs, withJitter(delayInSecs));
 
         // Reset the backoff if the delay reaches or exceeds the maximum limit

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -318,4 +318,24 @@ public class Utils {
     public static boolean isEmpty(@Nullable List value) {
         return (value == null || value.isEmpty());
     }
+
+    /**
+     * Converts time in milliseconds to a readable format of minutes and seconds.
+     *
+     * @param timeInMillis The time in milliseconds to be converted.
+     * @return A string representing the time in minutes and seconds.
+     */
+    public static String getTimeInReadableFormat(long timeInMillis) {
+        long totalSeconds = timeInMillis / 1000;
+        long minutes = totalSeconds / 60;
+        long seconds = totalSeconds % 60;
+
+        StringBuilder timeInReadableFormat = new StringBuilder();
+        if (minutes > 0) {
+            timeInReadableFormat.append(minutes).append("min ");
+        }
+        timeInReadableFormat.append(seconds).append("sec");
+
+        return timeInReadableFormat.toString();
+    }
 }

--- a/core/src/test/java/com/rudderstack/android/sdk/core/ExponentialBackOffTest.java
+++ b/core/src/test/java/com/rudderstack/android/sdk/core/ExponentialBackOffTest.java
@@ -1,0 +1,49 @@
+package com.rudderstack.android.sdk.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import com.rudderstack.android.sdk.core.util.ExponentialBackOff;
+
+public class ExponentialBackOffTest {
+
+    private ExponentialBackOff backOff;
+
+    @Before
+    public void setUp() {
+        backOff = new ExponentialBackOff(5 * 60) {
+            @Override
+            protected long withJitter(long delayInSecs) {
+                // Return a custom value for testing
+                long jitter = 1; // 1 sec
+                return delayInSecs + jitter;
+            }
+        };
+    }
+
+    @Test
+    public void testExponentialDelay() {
+        // Check delays for the first few attempts
+        long delay1 = backOff.nextDelayInMillis();
+        long delay2 = backOff.nextDelayInMillis();
+        long delay3 = backOff.nextDelayInMillis();
+
+        assertEquals((3 + 1) * 1000, delay1);       // Expected delay: (initialDelayInSecs * Math.pow(base, attempt)) * 1000
+        assertEquals(((3 * 2) + 1) * 1000, delay2); // Expected delay: (initialDelayInSecs * Math.pow(base, attempt)) * 1000
+        assertEquals(((3 * 4) + 1) * 1000, delay3); // Expected delay: (initialDelayInSecs * Math.pow(base, attempt)) * 1000
+    }
+
+    @Test
+    public void testResetBackOff() {
+        // Advance to exceed the max delay - 1
+        for (int i = 1; i <= 7; i++) {
+            backOff.nextDelayInMillis(); // At the 7th attempt, the delay will be 3 * 2^6 + 1 = 193 sec
+        }
+
+        long delayAfterReset = backOff.nextDelayInMillis(); // Should reset backoff
+        assertEquals(5 * 60 * 1000, delayAfterReset); // Expected delay: (initialDelayInSecs * Math.pow(base, attempt)) * 1000
+
+        long delayAfterReset2 = backOff.nextDelayInMillis(); // Should start from initial delay
+        assertEquals((3 + 1) * 1000, delayAfterReset2); // Expected delay: (initialDelayInSecs * Math.pow(base, attempt)) * 1000
+    }
+}


### PR DESCRIPTION
## Description

- This PR removes the existing retry mechanism for network errors and replaces it with an **exponential retry mechanism with jitter**. Now, retries will occur exponentially for every **4xx** and **5xx** status code (except 400 and 404). If the network is unavailable, retries will continue with a one-second delay.
- The maximum limit is 5 minutes; once this limit is reached, the retry process will start over from the beginning.
- Example sequence:
```
5sec, 7sec, 22 sec, 42 sec, 56 sec, 3 min 11 sec, 5 min 0 sec,
3 sec
```

**NOTE**: No event is deleted in this process.


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
