### PR TITLE
feat: add option to configure `dataPlaneUrl` as the metrics url

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,10 +44,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.6.0'
 
 
-    implementation 'com.rudderstack.android.sdk:rudderreporter:[0.4.0, 0.6.0)'
-//    implementation(project(path: ':rudderreporter'))
-//    implementation(project(path: ':gsonrudderadapter'))
-    implementation 'com.rudderstack.kotlin.sdk:gsonrudderadapter:[0.2.0, 0.3.0)'
+    implementation 'com.rudderstack.android.sdk:rudderreporter:0.6.0'
+    implementation 'com.rudderstack.kotlin.sdk:gsonrudderadapter:0.2.0'
 
     // required for new life cycle methods
     compileOnly 'androidx.lifecycle:lifecycle-process:2.6.1'

--- a/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/EventRepository.java
@@ -161,7 +161,7 @@ class EventRepository {
             if (serverConfig != null && serverConfig.source != null
                     && serverConfig.source.sourceConfiguration != null) {
                 RudderLogger.logDebug("EventRepository: constructor: Prefetched source serverConfig is available");
-                enableStatsCollection(application, writeKey, serverConfig.source.sourceConfiguration.getStatsCollection());
+                enableStatsCollection(application, writeKey, serverConfig.source.sourceConfiguration.getStatsCollection(), dataResidencyManager.getDataPlaneUrl());
             } else {
                 RudderLogger.logDebug("EventRepository: constructor: Prefetched source serverConfig is not available");
             }
@@ -271,8 +271,6 @@ class EventRepository {
                     if (serverConfig != null) {
                         isSDKEnabled = serverConfig.source.isSourceEnabled;
                         if (isSDKEnabled) {
-                            if (serverConfig.source.sourceConfiguration != null)
-                                enableStatsCollection(application, writeKey, serverConfig.source.sourceConfiguration.getStatsCollection());
                             dataResidencyManager.setDataResidencyUrls(serverConfig);
                             dataPlaneUrl = dataResidencyManager.getDataPlaneUrl();
                             if (dataPlaneUrl == null) {
@@ -281,6 +279,8 @@ class EventRepository {
                                         Collections.singletonMap(LABEL_TYPE, LABEL_TYPE_DATA_PLANE_URL_INVALID));
                                 return;
                             }
+                            if (serverConfig.source.sourceConfiguration != null)
+                                enableStatsCollection(application, writeKey, serverConfig.source.sourceConfiguration.getStatsCollection(), dataPlaneUrl);
                             if (consentFilter != null)
                                 this.consentFilterHandler = new ConsentFilterHandler(serverConfig.source, consentFilter);
                             cloudModeManager.startCloudModeProcessor();

--- a/core/src/main/java/com/rudderstack/android/sdk/core/ReportManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/ReportManager.java
@@ -100,8 +100,6 @@ public class ReportManager {
     private static final String FLUSH_WORKER_INIT_COUNTER_TAG = "flush_worker_init";
     private static final String ENCRYPTED_DB_COUNTER_TAG = "db_encrypt";
 
-    private static final String METRICS_URL_DEV = "https://sdk-metrics.dev-rudder.rudderlabs.com/";
-    private static final String METRICS_URL_PROD = "https://sdk-metrics.rudderstack.com/";
     private static Metrics metrics = null;
     private static ErrorClient errorStatsClient = null;
 
@@ -161,7 +159,7 @@ public class ReportManager {
 
     @SuppressWarnings("ConstantConditions")
     static void enableStatsCollection(Application application, String writeKey,
-                                      @NonNull SourceConfiguration.StatsCollection statsCollection) {
+                                      @NonNull SourceConfiguration.StatsCollection statsCollection, String dataPlaneUrl) {
         if (!isStatsReporterAvailable()) {
             if (!(statsCollection.getMetrics().isEnabled() || statsCollection.getErrors().isEnabled())) {
                 RudderLogger.logDebug("EventRepository: Stats collection is not enabled");
@@ -169,7 +167,7 @@ public class ReportManager {
             }
             RudderLogger.logDebug("EventRepository: Creating Stats Reporter");
             initiateRudderReporter(application, writeKey, statsCollection.getMetrics().isEnabled(),
-                    statsCollection.getErrors().isEnabled());
+                    statsCollection.getErrors().isEnabled(), dataPlaneUrl);
             RudderLogger.logDebug("EventRepository: Metrics collection is not initialized");
             return;
         }
@@ -211,10 +209,10 @@ public class ReportManager {
     }
 
     private static void initiateRudderReporter(Context context, @Nullable String writeKey,
-                                               boolean isMetricsEnabled, boolean isErrorsEnabled) {
+                                               boolean isMetricsEnabled, boolean isErrorsEnabled, String dataPlaneUrl) {
         RudderLogger.logDebug("EventRepository: Creating RudderReporter isMetricsEnabled: " + isMetricsEnabled + " isErrorsEnabled: " + isErrorsEnabled);
         if (rudderReporter == null) {
-            rudderReporter = new DefaultRudderReporter(context, METRICS_URL_PROD,
+            rudderReporter = new DefaultRudderReporter(context, dataPlaneUrl,
                     getStatsConfig(writeKey), new GsonAdapter(), isMetricsEnabled, isErrorsEnabled);
             rudderReporter.getSyncer().startScheduledSyncs(METRICS_UPLOAD_INTERVAL,
                     true, METRICS_FLUSH_COUNT);


### PR DESCRIPTION
## Description

- Add the option to configure `dataPlaneUrl` as the metrics URL and remove the default metric URL.
- Bump and fix the `rudderreporter` to `0.6.0`.
- Fix the `gsonrudderadapter` to `0.2.0`. (There is no change. We just fixed it to a particular version.)

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
