### PR TITLE
feat: change the metrics endpoint to `rsaMetrics`

### DIFF
--- a/.github/workflows/draft_new_release-v2.yml
+++ b/.github/workflows/draft_new_release-v2.yml
@@ -92,4 +92,4 @@ jobs:
           github_token: ${{ secrets.PAT }}
           pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master-v2'
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: 'itsdebs'
+          pr_reviewer: '@rudderlabs/sdk-android'

--- a/.github/workflows/publish-new-github-release-v2.yml
+++ b/.github/workflows/publish-new-github-release-v2.yml
@@ -77,7 +77,7 @@ jobs:
           github_token: ${{ secrets.PAT }}
           pr_title: 'chore(release): pulling master-v2 into develop-v2 post release v${{ steps.extract-version-v2.outputs.release_version }}'
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: 'itsdebs'
+          pr_reviewer: '@rudderlabs/sdk-android'
 
       - name: Delete hotfix release branch v2
         uses: koj-co/delete-merged-action@master

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ local.properties
 node_modules
 /.idea/
 */build
+/.nx

--- a/gsonrudderadapter/project.json
+++ b/gsonrudderadapter/project.json
@@ -13,7 +13,10 @@
           "target": "build"
         }
       ],
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/gsonrudderadapter/build"
       ]
@@ -31,7 +34,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/jacksonrudderadapter/project.json
+++ b/jacksonrudderadapter/project.json
@@ -13,7 +13,10 @@
           "target": "build"
         }
       ],
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/jacksonrudderadapter/build"
       ]
@@ -31,7 +34,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/models/project.json
+++ b/models/project.json
@@ -5,7 +5,10 @@
   "sourceRoot": "./models/src",
   "targets": {
     "build": {
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/models/build"
       ]
@@ -23,7 +26,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/moshirudderadapter/project.json
+++ b/moshirudderadapter/project.json
@@ -13,7 +13,10 @@
           "target": "build"
         }
       ],
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/moshirudderadapter/build"
       ]
@@ -25,7 +28,10 @@
       }
     },
     "test": {
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@commitlint/cli": "17.7.2",
         "@commitlint/config-conventional": "17.7.0",
         "@digitalroute/cz-conventional-changelog-for-jira": "8.0.1",
-        "@jnxplus/nx-gradle": "0.6.1",
+        "@jnxplus/nx-gradle": "1.7.4",
         "@jscutlery/semver": "3.1.0",
         "@nx/workspace": "16.10.0",
         "commitizen": "4.3.0",
@@ -550,6 +550,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-E7Vgw78I93we4ZWdYCb4DGAwRROGkMIXk7/y87UmANR+J6qsWusmC3gLt0H+O0KOt5e6O38U8oJamgbudrES/w==",
+      "dev": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
+      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
+      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
@@ -572,45 +600,760 @@
       }
     },
     "node_modules/@jnxplus/common": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@jnxplus/common/-/common-0.9.1.tgz",
-      "integrity": "sha512-e1Ev0vbWCPd4J8hSfAYD260QwqRDx4M8FJcYBTzzHg0RjH8JoEE9UecGJshNrvY/ZifgLeyVEiUU3xuC5GNpgQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@jnxplus/common/-/common-1.7.4.tgz",
+      "integrity": "sha512-OqWDFOq18MXHtzLhPF5BYVLefdumhyfFoecPKNt98kNayNN7us4uVlWjYi9ep0ppyR9bNI+XuzVoeic8mS4cWA==",
       "dev": true,
       "dependencies": {
-        "tslib": "2.5.0"
-      },
-      "peerDependencies": {
-        "@nx/devkit": ">=16.0.0"
+        "@nx/devkit": ">=17.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@jnxplus/gradle": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@jnxplus/gradle/-/gradle-0.13.2.tgz",
-      "integrity": "sha512-Lq4GrzKPy2RZOq44yUSOTWpCKuL7pZ1QUFB1qy6Dv3y3tW3tzQ1U6v73DT6tCKrdWzSCkMVOzuqcE1T7EKyOkw==",
+    "node_modules/@jnxplus/common/node_modules/@nrwl/devkit": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.5.7.tgz",
+      "integrity": "sha512-sTEwqsAT6bMturU14o/0O6v509OkwGOglxpbiL/zIYO/fDkMoNgnhlHBIT87i4YVuofMz2Z+hTfjDskzDPRSYw==",
       "dev": true,
       "dependencies": {
-        "@jnxplus/common": "0.9.1",
-        "tslib": "2.5.0"
+        "@nx/devkit": "19.5.7"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nrwl/tao": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.5.7.tgz",
+      "integrity": "sha512-c1rN6HY97+cEwoM5Q9412399Ac1rw7pI/3IS5iJSYkeI5TTGOobIpdCavJPZVcfqo4+wegXPA3F/OmulgbOUJA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "nx": "19.5.7",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "tao": "index.js"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/devkit": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.5.7.tgz",
+      "integrity": "sha512-mUtZQcdqbF0Q9HfyG14jmpPCtZ1GnVaLNIADZv5SLpFyfh4ZjaBw6wdjPj7Sp3imLoyqMrcd9nCRNO2hlem8bw==",
+      "dev": true,
+      "dependencies": {
+        "@nrwl/devkit": "19.5.7",
+        "ejs": "^3.1.7",
+        "enquirer": "~2.3.6",
+        "ignore": "^5.0.4",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.3",
+        "tmp": "~0.2.1",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
       },
       "peerDependencies": {
-        "@nx/devkit": ">=16.0.0"
+        "nx": ">= 17 <= 20"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-darwin-arm64": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.5.7.tgz",
+      "integrity": "sha512-5jFAZSfV8QVNoxOXayZw4/jNJbxMMctNOYZW8Qj4eU8Ti+OmhsLgouxz/9enCh5SDITriOMZ7IHZ9rhrlGQoig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-darwin-x64": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.5.7.tgz",
+      "integrity": "sha512-Ss+rF2+MQxyKrNnSYAeEGhtdE9hUHiTqyjJo4n1lvIWJ++TairOCtk5QRHrYLgAxE1XTf0OabcsDzegxv7yk3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-freebsd-x64": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.5.7.tgz",
+      "integrity": "sha512-FMLXcUr3mw/v4LvmNqHMAXy2k+T/hp2YpdBUq9ExteMfRywFsnKNlm39n/quniFsgKthEMdvvzxSQppRKaVwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.5.7.tgz",
+      "integrity": "sha512-LhJ342HutpR258lBLVTkXd6x2Uj4ZPJ6xKdfEm+FYQvG1byPr2L0TlNXcfSBkYtd7wRn0qg9eQZoCV/5+w415Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.5.7.tgz",
+      "integrity": "sha512-Q6gN+VNLisg7mYPTXC5JuGCP/s9tLjJFclKdH6FoP5K1Hgy88KK1uUoivDIfI8xaEgyLqphD1AAqokiFWZNWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.5.7.tgz",
+      "integrity": "sha512-BsYNcYujNKb+uE7PrJp4PrX8a3G9oy+THaUr0t5+L435HjuZDBiK+tK9JzYGvM0bR5FOYm5K99I1DVD/Hv0snw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.5.7.tgz",
+      "integrity": "sha512-ILaLU8b5lUokYVF3vxAVj62qFok1hexiNzBdLGJPI1OkPGELtLyb8RymI3939iJoNMk1DS3/6dqK7NHXvHX8Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.5.7.tgz",
+      "integrity": "sha512-LfTnO4JZebLugioMk+GTptv3N38Wj2i2Pko0bdRZaKba+INGSlUgFqoRuO0KqZEmVIUGrxfkfqIN3HghVQ4D/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.5.7.tgz",
+      "integrity": "sha512-cCTttdbf1AKuDU8j108SpIMWs53A/0mOVDPOPpa+oKkvBaI8ruZkxOceMjWZjWULd2gi1nS+5nJePpbrdQ8mkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.5.7.tgz",
+      "integrity": "sha512-EqSnjpq1PNR/C8/YkL+Gn79dDfQ+HwJM8VJOt4qoCOQ9gQZqNJphjW2hg0H8WxLYezMScx3fbL99mvJO7ab2Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/@zkochan/js-yaml": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
+      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/dotenv-expand": {
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.6.tgz",
+      "integrity": "sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "dotenv": "^16.4.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/nx": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-19.5.7.tgz",
+      "integrity": "sha512-AUmGgE19NB4m/7oHYQVdzZHtclVevD8w0/nNzzjDJE823T8oeoNhmc9MfCLz+/2l2KOp+Wqm+8LiG9/xWpXk0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@nrwl/tao": "19.5.7",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "3.0.0-rc.46",
+        "@zkochan/js-yaml": "0.0.7",
+        "axios": "^1.7.2",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^8.0.1",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "enquirer": "~2.3.6",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "front-matter": "^4.0.2",
+        "fs-extra": "^11.1.0",
+        "ignore": "^5.0.4",
+        "jest-diff": "^29.4.1",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "~2.0.3",
+        "minimatch": "9.0.3",
+        "node-machine-id": "1.1.12",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "ora": "5.3.0",
+        "semver": "^7.5.3",
+        "string-width": "^4.2.3",
+        "strong-log-transformer": "^2.1.0",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js",
+        "nx-cloud": "bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "19.5.7",
+        "@nx/nx-darwin-x64": "19.5.7",
+        "@nx/nx-freebsd-x64": "19.5.7",
+        "@nx/nx-linux-arm-gnueabihf": "19.5.7",
+        "@nx/nx-linux-arm64-gnu": "19.5.7",
+        "@nx/nx-linux-arm64-musl": "19.5.7",
+        "@nx/nx-linux-x64-gnu": "19.5.7",
+        "@nx/nx-linux-x64-musl": "19.5.7",
+        "@nx/nx-win32-arm64-msvc": "19.5.7",
+        "@nx/nx-win32-x64-msvc": "19.5.7"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.8.0",
+        "@swc/core": "^1.3.85"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jnxplus/common/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jnxplus/nx-gradle": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@jnxplus/nx-gradle/-/nx-gradle-0.6.1.tgz",
-      "integrity": "sha512-L4aj/QAUizu3iLhidzeB5KZWrsQSeEx2ss8m5gg5/GvlI1ubEUEobNiHT5GlS8jkxcU9TRdhS+d6xI1iwf8EgA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@jnxplus/nx-gradle/-/nx-gradle-1.7.4.tgz",
+      "integrity": "sha512-Kl4oNCZs3OlvUZl1joHIpBuGHNKhU+IY9htitNq31NSYxNl3Sy9HWKP2BWJkQFv4vx3rq3zysTjsKoqlMbPdxg==",
+      "dev": true,
+      "dependencies": {
+        "@jnxplus/common": "1.7.4",
+        "@nx/devkit": ">=17.0.0",
+        "nx": ">=17.0.0",
+        "smol-toml": "^1.1.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nrwl/devkit": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.5.7.tgz",
+      "integrity": "sha512-sTEwqsAT6bMturU14o/0O6v509OkwGOglxpbiL/zIYO/fDkMoNgnhlHBIT87i4YVuofMz2Z+hTfjDskzDPRSYw==",
+      "dev": true,
+      "dependencies": {
+        "@nx/devkit": "19.5.7"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nrwl/tao": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.5.7.tgz",
+      "integrity": "sha512-c1rN6HY97+cEwoM5Q9412399Ac1rw7pI/3IS5iJSYkeI5TTGOobIpdCavJPZVcfqo4+wegXPA3F/OmulgbOUJA==",
+      "dev": true,
+      "dependencies": {
+        "nx": "19.5.7",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "tao": "index.js"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/devkit": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.5.7.tgz",
+      "integrity": "sha512-mUtZQcdqbF0Q9HfyG14jmpPCtZ1GnVaLNIADZv5SLpFyfh4ZjaBw6wdjPj7Sp3imLoyqMrcd9nCRNO2hlem8bw==",
+      "dev": true,
+      "dependencies": {
+        "@nrwl/devkit": "19.5.7",
+        "ejs": "^3.1.7",
+        "enquirer": "~2.3.6",
+        "ignore": "^5.0.4",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.3",
+        "tmp": "~0.2.1",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
+      },
+      "peerDependencies": {
+        "nx": ">= 17 <= 20"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-darwin-arm64": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.5.7.tgz",
+      "integrity": "sha512-5jFAZSfV8QVNoxOXayZw4/jNJbxMMctNOYZW8Qj4eU8Ti+OmhsLgouxz/9enCh5SDITriOMZ7IHZ9rhrlGQoig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-darwin-x64": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.5.7.tgz",
+      "integrity": "sha512-Ss+rF2+MQxyKrNnSYAeEGhtdE9hUHiTqyjJo4n1lvIWJ++TairOCtk5QRHrYLgAxE1XTf0OabcsDzegxv7yk3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-freebsd-x64": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.5.7.tgz",
+      "integrity": "sha512-FMLXcUr3mw/v4LvmNqHMAXy2k+T/hp2YpdBUq9ExteMfRywFsnKNlm39n/quniFsgKthEMdvvzxSQppRKaVwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.5.7.tgz",
+      "integrity": "sha512-LhJ342HutpR258lBLVTkXd6x2Uj4ZPJ6xKdfEm+FYQvG1byPr2L0TlNXcfSBkYtd7wRn0qg9eQZoCV/5+w415Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.5.7.tgz",
+      "integrity": "sha512-Q6gN+VNLisg7mYPTXC5JuGCP/s9tLjJFclKdH6FoP5K1Hgy88KK1uUoivDIfI8xaEgyLqphD1AAqokiFWZNWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.5.7.tgz",
+      "integrity": "sha512-BsYNcYujNKb+uE7PrJp4PrX8a3G9oy+THaUr0t5+L435HjuZDBiK+tK9JzYGvM0bR5FOYm5K99I1DVD/Hv0snw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.5.7.tgz",
+      "integrity": "sha512-ILaLU8b5lUokYVF3vxAVj62qFok1hexiNzBdLGJPI1OkPGELtLyb8RymI3939iJoNMk1DS3/6dqK7NHXvHX8Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.5.7.tgz",
+      "integrity": "sha512-LfTnO4JZebLugioMk+GTptv3N38Wj2i2Pko0bdRZaKba+INGSlUgFqoRuO0KqZEmVIUGrxfkfqIN3HghVQ4D/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.5.7.tgz",
+      "integrity": "sha512-cCTttdbf1AKuDU8j108SpIMWs53A/0mOVDPOPpa+oKkvBaI8ruZkxOceMjWZjWULd2gi1nS+5nJePpbrdQ8mkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.5.7.tgz",
+      "integrity": "sha512-EqSnjpq1PNR/C8/YkL+Gn79dDfQ+HwJM8VJOt4qoCOQ9gQZqNJphjW2hg0H8WxLYezMScx3fbL99mvJO7ab2Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/@zkochan/js-yaml": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
+      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/dotenv-expand": {
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.6.tgz",
+      "integrity": "sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^16.4.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/nx": {
+      "version": "19.5.7",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-19.5.7.tgz",
+      "integrity": "sha512-AUmGgE19NB4m/7oHYQVdzZHtclVevD8w0/nNzzjDJE823T8oeoNhmc9MfCLz+/2l2KOp+Wqm+8LiG9/xWpXk0g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@jnxplus/common": "0.9.1",
-        "@jnxplus/gradle": "0.13.2",
-        "prettier": "^2.8.7",
-        "prettier-plugin-java": "^2.1.0",
-        "tslib": "2.5.0"
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@nrwl/tao": "19.5.7",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "3.0.0-rc.46",
+        "@zkochan/js-yaml": "0.0.7",
+        "axios": "^1.7.2",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^8.0.1",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "enquirer": "~2.3.6",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "front-matter": "^4.0.2",
+        "fs-extra": "^11.1.0",
+        "ignore": "^5.0.4",
+        "jest-diff": "^29.4.1",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "~2.0.3",
+        "minimatch": "9.0.3",
+        "node-machine-id": "1.1.12",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "ora": "5.3.0",
+        "semver": "^7.5.3",
+        "string-width": "^4.2.3",
+        "strong-log-transformer": "^2.1.0",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js",
+        "nx-cloud": "bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "19.5.7",
+        "@nx/nx-darwin-x64": "19.5.7",
+        "@nx/nx-freebsd-x64": "19.5.7",
+        "@nx/nx-linux-arm-gnueabihf": "19.5.7",
+        "@nx/nx-linux-arm64-gnu": "19.5.7",
+        "@nx/nx-linux-arm64-musl": "19.5.7",
+        "@nx/nx-linux-x64-gnu": "19.5.7",
+        "@nx/nx-linux-x64-musl": "19.5.7",
+        "@nx/nx-win32-arm64-msvc": "19.5.7",
+        "@nx/nx-win32-x64-msvc": "19.5.7"
       },
       "peerDependencies": {
-        "@nx/devkit": ">=16.3.0"
+        "@swc-node/register": "^1.8.0",
+        "@swc/core": "^1.3.85"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jnxplus/nx-gradle/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -684,6 +1427,17 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
     "node_modules/@nrwl/devkit": {
       "version": "16.10.0",
       "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.10.0.tgz",
@@ -705,12 +1459,6 @@
       "bin": {
         "tao": "index.js"
       }
-    },
-    "node_modules/@nrwl/tao/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@nrwl/workspace": {
       "version": "16.10.0",
@@ -753,12 +1501,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@nx/devkit/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@nx/nx-darwin-arm64": {
       "version": "16.10.0",
@@ -933,12 +1675,6 @@
         "yargs-parser": "21.1.1"
       }
     },
-    "node_modules/@nx/workspace/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@parcel/watcher": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
@@ -1023,6 +1759,15 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
@@ -1081,12 +1826,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.6",
@@ -1261,12 +2000,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -1459,15 +2198,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/chevrotain": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.5.0.tgz",
-      "integrity": "sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==",
-      "dev": true,
-      "dependencies": {
-        "regexp-to-ast": "0.4.0"
-      }
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -2525,9 +3255,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -2556,6 +3286,37 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "node_modules/front-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/front-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/fs-constants": {
@@ -3215,16 +3976,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/java-parser": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.0.5.tgz",
-      "integrity": "sha512-AwieTO24Itcu0GgP9pBXs8gkqBtkmReclpBgXF4NkbIjdS7cn7hqpebjTmb5ouYYLFR+m3yh5fR3nW1NRrthdg==",
-      "dev": true,
-      "dependencies": {
-        "chevrotain": "6.5.0",
-        "lodash": "4.17.21"
       }
     },
     "node_modules/jest-diff": {
@@ -4032,12 +4783,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/nx/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4256,47 +5001,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-plugin-java": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-2.3.1.tgz",
-      "integrity": "sha512-OYn8skqKnE5YUVL8f2ocayA6XCJK8PqsEz3pfATbDqzgdaSYDLhE/s8KrXrX9gj8KXIG6Wx0CMoXTNH8+ED22w==",
-      "dev": true,
-      "dependencies": {
-        "java-parser": "2.0.5",
-        "lodash": "4.17.21",
-        "prettier": "3.0.3"
-      }
-    },
-    "node_modules/prettier-plugin-java/node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -4545,12 +5249,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/regexp-to-ast": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
-      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
-      "dev": true
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4675,12 +5373,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4748,6 +5440,18 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/smol-toml": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.0.tgz",
+      "integrity": "sha512-tWpi2TsODPScmi48b/OQZGi2lgUmBCHy6SZrhi/FdnnHiU1GwebbCfuQuxsC3nHaLwtYeJGPrDZDIeodDOc4pA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -5106,9 +5810,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "dev": true
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@jscutlery/semver": "3.1.0",
     "commitizen": "4.3.0",
     "commitlint": "17.7.2",
-    "@jnxplus/nx-gradle": "0.6.1",
+    "@jnxplus/nx-gradle": "1.7.4",
     "@nx/workspace": "16.10.0",
     "nx": "16.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "ktformat": "nx affected --base=origin/master-v2 --target=ktformat --parallel=1 --exclude=app,core,android --skipCommitTypes=docs,ci,chore",
     "sync-version-gradle": "nx affected --target=sync-bumped-version-properties --parallel=1 --exclude=app,core,android --skipCommitTypes=docs,ci,chore",
     "test": "nx affected --base=origin/master-v2 --target='test' --parallel=1 --exclude=app,core,android --skipCommitTypes=docs,ci,chore",
-    "release": "nx affected --base=origin/master-v2 --target=version --parallel=1 --exclude=app,core,android --skipCommitTypes=docs,ci,chore && npm run sync-version-gradle",
-    "release:github": "nx affected --target=github --parallel=1 --exclude=app,core,android --skipCommitTypes=docs,ci,chore",
-    "release:sonatype": "nx affected --base=origin/master-v2 --target=release-sonatype --parallel=1 --exclude=app,core,android",
-    "release-snapshot:sonatype": "nx affected --base=origin/master-v2 --target=snapshot-release --parallel=1 --exclude=app,core,android"
+    "release": "nx affected --base=origin/master-v2 --target=version --parallel=1 --exclude=app,core,android,web,gsonrudderadapter,models,rudderjsonadapter,jacksonrudderadapter,moshirudderadapter --skipCommitTypes=docs,ci,chore && npm run sync-version-gradle",
+    "release:github": "nx affected --target=github --parallel=1 --exclude=app,core,android,web,gsonrudderadapter,models,rudderjsonadapter,jacksonrudderadapter,moshirudderadapter --skipCommitTypes=docs,ci,chore",
+    "release:sonatype": "nx affected --base=origin/master-v2 --target=release-sonatype --parallel=1 --exclude=app,core,android,web,gsonrudderadapter,models,rudderjsonadapter,jacksonrudderadapter,moshirudderadapter",
+    "release-snapshot:sonatype": "nx affected --base=origin/master-v2 --target=snapshot-release --parallel=1 --exclude=app,core,android,web,gsonrudderadapter,models,rudderjsonadapter,jacksonrudderadapter,moshirudderadapter"
   },
   "private": true,
   "devDependencies": {

--- a/repository/project.json
+++ b/repository/project.json
@@ -5,7 +5,10 @@
   "sourceRoot": "./repository/src",
   "targets": {
     "build": {
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/repository/build"
       ]
@@ -23,7 +26,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/rudderjsonadapter/project.json
+++ b/rudderjsonadapter/project.json
@@ -5,7 +5,10 @@
   "sourceRoot": "./rudderjsonadapter/src",
   "targets": {
     "build": {
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/rudderjsonadapter/build"
       ]
@@ -23,7 +26,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/rudderreporter/project.json
+++ b/rudderreporter/project.json
@@ -17,7 +17,10 @@
           "target": "build"
         }
       ],
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/rudderreporter/build"
       ]
@@ -35,7 +38,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"

--- a/rudderreporter/src/main/java/com/rudderstack/android/ruddermetricsreporterandroid/internal/DefaultUploadMediator.kt
+++ b/rudderreporter/src/main/java/com/rudderstack/android/ruddermetricsreporterandroid/internal/DefaultUploadMediator.kt
@@ -74,6 +74,6 @@ internal class DefaultUploadMediator(
         private const val METRICS_KEY = "metrics"
         private const val ERROR_KEY = "errors"
         private const val VERSION_KEY = "version"
-        private const val METRICS_ENDPOINT = "sdkmetrics"
+        private const val METRICS_ENDPOINT = "rsaMetrics"
     }
 }

--- a/web/project.json
+++ b/web/project.json
@@ -15,7 +15,10 @@
           "target": "build"
         }
       ],
-      "executor": "@jnxplus/nx-gradle:build",
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "build"
+      },
       "outputs": [
         "{projectRoot}/web/build"
       ]
@@ -33,7 +36,10 @@
       "dependsOn": [
         "build"
       ],
-      "executor": "@jnxplus/nx-gradle:test"
+      "executor": "@jnxplus/nx-gradle:run-task",
+      "options": {
+        "task": "test"
+      }
     },
     "ktformat": {
       "executor": "@jnxplus/nx-gradle:ktformat"


### PR DESCRIPTION
## Description

- In this PR, we've updated the metrics endpoint from `sdkmetrics` to `rsaMetrics`.
- The PR reviewer has also been updated.
- CI: Updated build and test executors in all modules.
- CI: Exclude all modules from releasing except `repository` and `rudderreporter`. These change has been done for `release` (Changelog generation), `release:github` (Push GitHub releases), `release:sonatype` (Releasing the affected packages to sonatype) and `release-snapshot:sonatype` (Releasing snapshot versions to sonatype).

**NOTE**: Instead of the next minor version `0.5.0`, we need to release these changes in version `0.6.0`, as the v1 SDK depends upon [0.4.0, 0.6.0). So if we release it as `0.5.0`, it might cause an issue. Therefore, I've manually created and pushed [rudderreporter@0.5.0](https://github.com/rudderlabs/rudder-sdk-android/releases/tag/rudderreporter%400.5.0) tag (this is based on master-v2).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
