### PR TITLE
fix: handle db crash issue on Amazon devices

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistence.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistence.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.SQLException;
+import android.database.sqlite.SQLiteCantOpenDatabaseException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
@@ -258,7 +259,12 @@ public class DefaultPersistence extends SQLiteOpenHelper implements Persistence 
 
     @Override
     public boolean isAccessible() {
-        return getWritableDatabase().isOpen();
+         try {
+             return getWritableDatabase().isOpen();
+         }  catch (SQLiteCantOpenDatabaseException ex) {
+             RudderLogger.logError("DBPersistentManager: isDBAccessible: Exception while checking the accessibility of the database due to " + ex);
+             return false;
+         }
     }
     static class DbParams {
         final String dbName;

--- a/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistence.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/persistence/DefaultPersistence.java
@@ -262,7 +262,7 @@ public class DefaultPersistence extends SQLiteOpenHelper implements Persistence 
          try {
              return getWritableDatabase().isOpen();
          }  catch (SQLiteCantOpenDatabaseException ex) {
-             RudderLogger.logError("DBPersistentManager: isDBAccessible: Exception while checking the accessibility of the database due to " + ex);
+             RudderLogger.logError("DefaultPersistence: isAccessible: Exception while checking the accessibility of the database due to " + ex);
              return false;
          }
     }


### PR DESCRIPTION
## Description

- In this PR, we are handling the database crash issue caused on Amazon devices when the app is mostly in the background.
- We are catching `SQLiteCantOpenDatabaseException` when we check if the database is accessible or not and if an exception occurs we return false indicating the database is not accessible.
- If such an exception occurs then all the events will be lost.
- Values like userId, traits, etc., not stored in the database will continue to be stored in shared preferences as usual.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
