### PR TITLE
feat: add alias api with previousId support

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
@@ -467,7 +467,11 @@ public class RudderClient {
      * @param newId New userId for the user
      */
     public void alias(String newId) {
-        alias(newId, null);
+        alias(newId, null, null);
+    }
+
+    public void alias(@NonNull String newId, @Nullable RudderOption option) {
+        alias(newId, option, null);
     }
 
     /**
@@ -478,7 +482,7 @@ public class RudderClient {
      * @param newId  New userId for the user
      * @param option RudderOptions for this event
      */
-    public void alias(@NonNull String newId, @Nullable RudderOption option) {
+    public void alias(@NonNull String newId, @Nullable RudderOption option, @Nullable String previousId) {
         RudderContext context = getRudderContext();
         Map<String, Object> traits = null;
         if (context != null) {
@@ -488,12 +492,16 @@ public class RudderClient {
             return;
         String prevUserId = null;
 
-        if (traits.containsKey("userId")) {
-            prevUserId = (String) traits.get("userId");
-        } else if (traits.containsKey("id")) {
-            prevUserId = (String) traits.get("id");
+        if (previousId != null) {
+            prevUserId = previousId;
         } else {
-            prevUserId = RudderContext.getAnonymousId();
+            if (traits.containsKey("userId")) {
+                prevUserId = (String) traits.get("userId");
+            } else if (traits.containsKey("id")) {
+                prevUserId = (String) traits.get("id");
+            } else {
+                prevUserId = RudderContext.getAnonymousId();
+            }
         }
 
         traits.put("userId", newId);


### PR DESCRIPTION
## Description

- Added an `Alias` API with `previousId` support. Now, `previousId` can be passed and will be preferred over the existing `userId` or `anonymousId`.
- New Alias API:
```
public void alias(@NonNull String newId, @Nullable RudderOption option, @Nullable String previousId)
```
- This is to bring it in parity with the JS SDK so that `previousId` can be explicitly passed if needed.

NOTE: The change is backwards compatible, as we are introducing a new Alias API which adds a new behaviour to the existing payload schema.

## How to test

Objective: We need to test, if `previousId` is passed then it should be used, else the existing behaviour should continue i.e., userId or anonymousId should be used.

- Make an `alias` event and explicitly pass `previousId` field -> It should be set as the `previousId`.
- Existing API: Make an Identify event, then `RESET` call and then an `alias` event (with previousId) -> `previousId` should be set as passed previousId.
- Existing API: Make an `alias` event with only `newId` -> `previousId` should be set as `anonymousId`.
- Existing API: Make an `alias` event with only `newId` and `options` -> `previousId` should be set as `anonymousId`.
- Existing API: Make an `identify` event and then an `alias` event (without previousId) -> `previousId` should be set as previous userId.
- Existing API: Make an Identify event, then `RESET` call and then an `alias` event (without previousId) -> `previousId` should be set as `anonymousId`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
