### PR TITLE
refactor: catch OutOfMemoryError in RudderCloudModeManager

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -108,7 +108,7 @@ public class RudderCloudModeManager {
                         RudderLogger.logError(String.format("CloudModeManager: cloudModeProcessor: Exception while trying to send events to Data plane URL %s due to %s", config.getDataPlaneUrl(), ex.getLocalizedMessage()));
                         Thread.currentThread().interrupt();
                     } catch (OutOfMemoryError e) {
-                        RudderLogger.logError("CloudModeManager: cloudModeProcessor: Out of memory error occurred while trying to send events to Data plane URL " + config.getDataPlaneUrl());
+                        RudderLogger.logError(String.format("CloudModeManager: cloudModeProcessor: Out of memory error: %s occurred while trying to send events to Data plane URL: %s", e.getLocalizedMessage(), config.getDataPlaneUrl()));
                         // sleeping the thread for 1s to avoid continuous loop after OOM.
                         Utils.sleep(1000);
                     }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -44,39 +44,39 @@ public class RudderCloudModeManager {
                 final ArrayList<String> messages = new ArrayList<>();
                 final ExponentialBackOff exponentialBackOff = new ExponentialBackOff(5 * 60); // 5 minutes
                 while (true) {
-                    // clear lists for reuse
-                    messageIds.clear();
-                    messages.clear();
-                    result = null;
-                    maintainDBThreshold();
-                    long sleepCount = Utils.getSleepDurationInSecond(upTimeInMillis, Utils.getUpTimeInMillis());
-                    RudderLogger.logDebug("CloudModeManager: cloudModeProcessor: Fetching events to flush to server");
-                    synchronized (MessageUploadLock.UPLOAD_LOCK) {
-                        dbManager.fetchCloudModeEventsFromDB(messageIds, messages, config.getFlushQueueSize());
-                        if (messages.size() >= config.getFlushQueueSize() || (!messages.isEmpty() && sleepCount >= config.getSleepTimeOut())) {
-                            // form payload JSON form the list of messages
-                            String payload = FlushUtils.getPayloadFromMessages(messageIds, messages);
-                            RudderLogger.logDebug(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: payload: %s", payload));
-                            RudderLogger.logInfo(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: %d", messageIds.size()));
-                            if (payload != null) {
-                                result = networkManager.sendNetworkRequest(payload, addEndPoint(dataResidencyManager.getDataPlaneUrl(), BATCH_ENDPOINT), RequestMethod.POST, true);
-                                RudderLogger.logInfo(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: ServerResponse: %d", result.statusCode));
-                                if (result.status == NetworkResponses.SUCCESS) {
-                                    ReportManager.incrementCloudModeUploadSuccessCounter(messageIds.size());
-                                    cleanUpEvents(messageIds);
-                                    exponentialBackOff.resetBackOff();                                  
-                                    upTimeInMillis = Utils.getUpTimeInMillis();
-                                    sleepCount = Utils.getSleepDurationInSecond(upTimeInMillis, Utils.getUpTimeInMillis());
+                    try {
+                        // clear lists for reuse
+                        messageIds.clear();
+                        messages.clear();
+                        result = null;
+                        maintainDBThreshold();
+                        long sleepCount = Utils.getSleepDurationInSecond(upTimeInMillis, Utils.getUpTimeInMillis());
+                        RudderLogger.logDebug("CloudModeManager: cloudModeProcessor: Fetching events to flush to server");
+                        synchronized (MessageUploadLock.UPLOAD_LOCK) {
+                            dbManager.fetchCloudModeEventsFromDB(messageIds, messages, config.getFlushQueueSize());
+                            if (messages.size() >= config.getFlushQueueSize() || (!messages.isEmpty() && sleepCount >= config.getSleepTimeOut())) {
+                                // form payload JSON form the list of messages
+                                String payload = FlushUtils.getPayloadFromMessages(messageIds, messages);
+                                RudderLogger.logDebug(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: payload: %s", payload));
+                                RudderLogger.logInfo(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: %d", messageIds.size()));
+                                if (payload != null) {
+                                    result = networkManager.sendNetworkRequest(payload, addEndPoint(dataResidencyManager.getDataPlaneUrl(), BATCH_ENDPOINT), RequestMethod.POST, true);
+                                    RudderLogger.logInfo(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: ServerResponse: %d", result.statusCode));
+                                    if (result.status == NetworkResponses.SUCCESS) {
+                                        ReportManager.incrementCloudModeUploadSuccessCounter(messageIds.size());
+                                        cleanUpEvents(messageIds);
+                                        exponentialBackOff.resetBackOff();
+                                        upTimeInMillis = Utils.getUpTimeInMillis();
+                                        sleepCount = Utils.getSleepDurationInSecond(upTimeInMillis, Utils.getUpTimeInMillis());
+                                    } else {
+                                        incrementCloudModeUploadRetryCounter(1);
+                                    }
                                 } else {
-                                    incrementCloudModeUploadRetryCounter(1);
+                                    cleanUpEvents(messageIds);
                                 }
-                            } else {
-                                cleanUpEvents(messageIds);
                             }
                         }
-                    }
-                    RudderLogger.logDebug(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: SleepCount: %d", sleepCount));
-                    try {
+                        RudderLogger.logDebug(String.format(Locale.US, "CloudModeManager: cloudModeProcessor: SleepCount: %d", sleepCount));
                         if (result == null) {
                             RudderLogger.logDebug("CloudModeManager: cloudModeProcessor: Sleeping for next: " + config.getEventDispatchSleepInterval() + "ms");
                             Thread.sleep(config.getEventDispatchSleepInterval());
@@ -107,6 +107,10 @@ public class RudderCloudModeManager {
                         ReportManager.reportError(ex);
                         RudderLogger.logError(String.format("CloudModeManager: cloudModeProcessor: Exception while trying to send events to Data plane URL %s due to %s", config.getDataPlaneUrl(), ex.getLocalizedMessage()));
                         Thread.currentThread().interrupt();
+                    } catch (OutOfMemoryError e) {
+                        RudderLogger.logError("CloudModeManager: cloudModeProcessor: Out of memory error occurred while trying to send events to Data plane URL " + config.getDataPlaneUrl());
+                        // sleeping the thread for 1s to avoid continuous loop after OOM.
+                        Utils.sleep(1000);
                     }
                 }
             }

--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -347,4 +347,13 @@ public class Utils {
 
         return timeInReadableFormat.toString();
     }
+
+    public static void sleep(long timeInMillis) {
+        try {
+            Thread.sleep(timeInMillis);
+        } catch (InterruptedException ex) {
+            ReportManager.reportError(ex);
+            Thread.currentThread().interrupt();
+        }
+    }
 }


### PR DESCRIPTION
## Description

- This PR resolves the fatal error caused by `OutOfMemoryError` in `RudderCloudModeManager`. 

## Implementation details

- The error actually occurs in `DBPersistentManager` in `getDBRecordCount` method. This method is called in `maintainDBThreshold` method which is in turn called in a thread in `startCloudModeProcessor`. 
- The error is unrelated to any database operations and occurs at OS level, therefore this PR catches the error and logs a message in `startCloudModeProcessor` in `RudderCloudModeManager`.
- During the catching of the error, a Thread.sleep is added to prevent the while loop from running constantly in case the exception is thrown again.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
