### PR TITLE
chore: correct `alias` api by adding previousId argument in the middle

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
@@ -471,7 +471,7 @@ public class RudderClient {
     }
 
     public void alias(@NonNull String newId, @Nullable RudderOption option) {
-        alias(newId, option, null);
+        alias(newId, null, option);
     }
 
     /**
@@ -482,7 +482,7 @@ public class RudderClient {
      * @param newId  New userId for the user
      * @param option RudderOptions for this event
      */
-    public void alias(@NonNull String newId, @Nullable RudderOption option, @Nullable String previousId) {
+    public void alias(@NonNull String newId, @Nullable String previousId, @Nullable RudderOption option) {
         RudderContext context = getRudderContext();
         Map<String, Object> traits = null;
         if (context != null) {

--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderClient.java
@@ -477,9 +477,8 @@ public class RudderClient {
     /**
      * Alias call
      *
-     * <b>Segment compatible API</b>
-     *
      * @param newId  New userId for the user
+     * @param previousId Previous userId for the user
      * @param option RudderOptions for this event
      */
     public void alias(@NonNull String newId, @Nullable String previousId, @Nullable RudderOption option) {


### PR DESCRIPTION
## Description

- Change the `alias` API
from:
```
public void alias(@NonNull String newId, @Nullable RudderOption option, @Nullable String previousId)
```
to
```
public void alias(@NonNull String newId, @Nullable String previousId, @Nullable RudderOption option)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
