### PR TITLE
feat: increase MAX_EVENT_SIZE from 32 KB to 64 KB

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/util/Utils.java
@@ -46,7 +46,7 @@ public class Utils {
     public static final int MIN_SLEEP_TIMEOUT = 1;
     public static final int MIN_FLUSH_QUEUE_SIZE = 1;
     public static final int MAX_FLUSH_QUEUE_SIZE = 100;
-    public static final int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
+    public static final int MAX_EVENT_SIZE = 64 * 1024; // 64 KB
     public static final int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 
     public static String getTimeZone() {


### PR DESCRIPTION
# Description

- We have updated the hard limit on event ingestion size from 32 KB to 64KB. 
- So, now SDK allows to make an event of size less than or equal to 64 KB.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test

- Previously, we log the following error message with the event size limit of 32 KB:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/2969c375-ab01-4c95-a026-f492a35cbb42" />
- Now, we log the following error message with the event size limit of 64 KB:
<img width="992" alt="image" src="https://github.com/user-attachments/assets/8b85e43e-3049-4ef1-9112-4ee09cb75d1f" />

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
