### PR TITLE
fix: resolve NPE issue in the custom factory feature

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderDeviceModeManager.java
@@ -498,7 +498,10 @@ public class RudderDeviceModeManager {
      */
     private boolean isEventAllowed(RudderMessage message, String destinationName) {
         Boolean isDestinationEnabledForMessage = isDestinationEnabled(destinationName, message);
-        Boolean isEventAllowedForDestination = rudderEventFilteringPlugin.isEventAllowed(destinationName, message);
+        boolean isEventAllowedForDestination = true;
+        if (rudderEventFilteringPlugin != null) {
+            isEventAllowedForDestination = rudderEventFilteringPlugin.isEventAllowed(destinationName, message);
+        }
         return isDestinationEnabledForMessage && isEventAllowedForDestination;
     }
 

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -14,7 +14,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:theme="@style/AppTheme"
+        tools:targetApi="n">
         <activity
             android:name="com.rudderstack.android.sample.kotlin.MainActivity"
             android:exported="true">

--- a/sample-kotlin/src/main/res/xml/network_security_config.xml
+++ b/sample-kotlin/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">76231d09.ngrok.io</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
# Description

- Added a fix to avoid NPE (NullPointerException) which occurs if custom factory is added and the Android source doesn't have any destination attached to it. Now, we are first checking if eventFilteringPlugin object is null or not before accessing it, which prevents the NPE.
- I also updated the `networkSecurityConfig` in the sample app. This will be helpful to test the localhost URL.

## Testing
- I've ensured that existing event filtering functionality works as expected.
- I've ensure that custom factory integration works as expected and doesn't throw any exception.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
