### PR TITLE
ci: set java to v11 in the release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: deployment
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '11'
       - uses: actions/checkout@v4
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: deployment
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '11'
       - uses: actions/checkout@v4
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
# Description

This is to fix the failing test in the release github actions. Refer here: https://github.com/rudderlabs/rudder-sdk-android/actions/runs/13965287907/job/39094393380?pr=502 for the failing action, we need to set the Java to v11. For build it's already set to v11.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
