### PR TITLE
fix: resolved crash caused by a race condition in session logic

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderUserSession.java
@@ -33,16 +33,13 @@ class RudderUserSession {
         RudderLogger.logDebug(String.format(Locale.US, "Starting new session with id: %s", sessionId));
     }
 
-
-    public void startSessionIfNeeded() {
+    public synchronized void startSessionIfNeeded() {
         if (this.lastActiveTimestamp == null) {
             this.startSession();
             return;
         }
         final long timeDifference;
-        synchronized (this) {
-            timeDifference = Math.abs((Utils.getCurrentTimeInMilliSeconds() - this.lastActiveTimestamp));
-        }
+        timeDifference = Math.abs((Utils.getCurrentTimeInMilliSeconds() - this.lastActiveTimestamp));
         if (timeDifference > this.config.getSessionTimeout()) {
             refreshSession();
         }


### PR DESCRIPTION
# Description:

- Previously, due to a race condition in the session logic, the SDK was throwing a fatal exception. This race condition can happen when the app is moved to the foreground and a RESET call is made, leading to a fatal exception.
- We have fixed the race condition by synchronizing `startSessionIfNeeded` method.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
