### PR TITLE
fix: handle SQLiteFullException in event saving and flushing logic

### DIFF
--- a/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
+++ b/core/src/main/java/com/rudderstack/android/sdk/core/RudderCloudModeManager.java
@@ -107,6 +107,7 @@ public class RudderCloudModeManager {
                         ReportManager.reportError(ex);
                         RudderLogger.logError(String.format("CloudModeManager: cloudModeProcessor: Exception while trying to send events to Data plane URL %s due to %s", config.getDataPlaneUrl(), ex.getLocalizedMessage()));
                         Thread.currentThread().interrupt();
+                        Utils.sleep(1000);
                     } catch (OutOfMemoryError e) {
                         RudderLogger.logError(String.format("CloudModeManager: cloudModeProcessor: Out of memory error: %s occurred while trying to send events to Data plane URL: %s", e.getLocalizedMessage(), config.getDataPlaneUrl()));
                         // sleeping the thread for 1s to avoid continuous loop after OOM.


### PR DESCRIPTION
## Description

- Added the logic to catch the `SQLiteFullException` in the `DBPersistentManager.java` and `FlushUtils.java`.
- Also, added a 1-second sleep in case of an exception in `RudderCloudModeManager.java`.

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
