### PR TITLE
chore: add members read permission to app token for team reviewer resolution

### DIFF
--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -28,6 +28,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits, tags, and releases
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to resolve org team reviewers
 
       - name: Extract version from branch name (for release branches)
         id: extract-version


### PR DESCRIPTION
**Fixes** SDK-4571

## Description

The "Publish new release" GitHub Actions workflow fails at the "Create pull request into develop" step when trying to assign `@rudderlabs/sdk-android` as a team reviewer. The GitHub App token was missing `members:read` permission, which is required for the API to resolve organization team slugs during reviewer assignment.

This adds `permission-members: read` to the app token generation step in `publish-new-github-release.yml`.

**Note:** The GitHub App (configured via `RELEASE_APP_ID`) must also have "Organization members: Read" enabled in its app settings on GitHub for this to take effect.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
