### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: "@rudderlabs/sdk-android"
+assignees: []
 ---
 
 **Describe the bug**

--- a/.github/workflows/draft_new_release-v2.yml
+++ b/.github/workflows/draft_new_release-v2.yml
@@ -120,4 +120,4 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master-v2'
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-android'
+          pr_reviewer: '@rudderlabs/sdk_team'

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -111,4 +111,4 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into ${{ steps.create-release.outputs.main_branch }}"
           pr_body:  ":crown: *An automated PR*"
-          pr_reviewer: '@rudderlabs/sdk-android'
+          pr_reviewer: '@rudderlabs/sdk_team'

--- a/.github/workflows/publish-new-github-release-v2.yml
+++ b/.github/workflows/publish-new-github-release-v2.yml
@@ -113,7 +113,7 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling master-v2 into develop-v2 post release v${{ steps.extract-version-v2.outputs.release_version }}'
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-android'
+          pr_reviewer: '@rudderlabs/sdk_team'
 
       - name: Delete hotfix release branch v2
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -67,7 +67,7 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling main into develop post release v${{ steps.extract-version.outputs.release_version }}"
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-android'
+          pr_reviewer: '@rudderlabs/sdk_team'
       - name: Create pull request into develop-mpx
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         if: (startsWith(github.event.pull_request.head.ref, 'release-mpx/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release-mpx/'))
@@ -77,7 +77,7 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling main into develop post release v${{ steps.extract-version.outputs.release_version }}"
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-android'
+          pr_reviewer: '@rudderlabs/sdk_team'
 
       - name: Delete hotfix release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rudderlabs/sdk-android
+* @rudderlabs/sdk_team


### PR DESCRIPTION
**Fixes** [SDK-5169](https://linear.app/rudderstack/issue/SDK-5169/set-sdk-team-as-code-owners-in-rudder-sdk-android)

Replaces `@rudderlabs/sdk-android` with `@rudderlabs/sdk_team` as the repo's code owners so any SDK team member's review can unblock chore PRs (Dependabot merges, CI fixes). Also updates the release workflows' `pr_reviewer` to the same team and clears the non-functional team assignee from the bug-report issue template. Brings this repo in line with the other SDK repos already migrated.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
