### PR TITLE
fix(core): scope Serializable consumer proguard rule to config classes

### DIFF
--- a/core/proguard-consumer-rules.pro
+++ b/core/proguard-consumer-rules.pro
@@ -26,7 +26,22 @@
 
 # Required for the serialization of SourceConfig once it is downloaded.
 -keep class com.google.gson.internal.LinkedTreeMap { *; }
--keep class * implements java.io.Serializable { *; }
+# Scoped to the object graphs actually written via ObjectOutputStream:
+#   RudderServerConfigManager -> RudderServerConfig
+#   RudderFlushWorkManager    -> RudderFlushConfig
+# Field names, field types and nested/enum types all feed Java serialization,
+# so the whole reachable graph must be kept - including the nested classes of
+# SourceConfiguration and the RudderDataResidencyServer enum, which a plain
+# outer-class keep does not cover.
+-keep class com.rudderstack.android.sdk.core.RudderServerConfig { *; }
+-keep class com.rudderstack.android.sdk.core.RudderServerConfigSource { *; }
+-keep class com.rudderstack.android.sdk.core.RudderServerDestination { *; }
+-keep class com.rudderstack.android.sdk.core.RudderServerDestinationDefinition { *; }
+-keep class com.rudderstack.android.sdk.core.RudderDataResidencyUrls { *; }
+-keep class com.rudderstack.android.sdk.core.RudderDataResidencyServer { *; }
+-keep class com.rudderstack.android.sdk.core.SourceConfiguration { *; }
+-keep class com.rudderstack.android.sdk.core.SourceConfiguration$* { *; }
+-keep class com.rudderstack.android.sdk.core.RudderFlushConfig { *; }
 -keep class com.rudderstack.rudderjsonadapter.RudderTypeAdapter { *; }
 -keep class * extends com.rudderstack.rudderjsonadapter.RudderTypeAdapter
 


### PR DESCRIPTION
**Fixes** SDK-5190 (parent: SDK-5136)

## Description

The core SDK ships the consumer proguard rule `-keep class * implements java.io.Serializable { *; }`. Because it is a *consumer* rule, it is merged into every host app's R8 configuration and applies **app-wide**, not just to the SDK. As a result it blocks R8 shrinking/obfuscation/optimization on any class in the host app that implements `Serializable` (which includes every `Throwable`/`Exception` and most model classes) — a customer (Cloudwalk) measured ~18.6% of classes in their app being kept because of this single rule.

The wildcard was only ever needed to protect the two object graphs the SDK actually persists via Java serialization (`ObjectOutputStream`):

- `RudderServerConfigManager` → `RudderServerConfig`
- `RudderFlushWorkManager` → `RudderFlushConfig`

This PR replaces the app-wide wildcard with explicit `-keep` rules scoped to exactly those graphs, so the SDK stops constraining unrelated host-app code.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Implementation Details
- Removed `-keep class * implements java.io.Serializable { *; }` from `core/proguard-consumer-rules.pro`.
- Added explicit keeps for the persisted `RudderServerConfig` / `RudderFlushConfig` object graphs: `RudderServerConfig`, `RudderServerConfigSource`, `RudderServerDestination`, `RudderServerDestinationDefinition`, `RudderDataResidencyUrls`, `RudderDataResidencyServer`, `SourceConfiguration`, `SourceConfiguration$*`, `RudderFlushConfig`.
- Included the `SourceConfiguration` nested classes (`$*`) and the `RudderDataResidencyServer` enum explicitly — a plain outer-class keep does not cover nested types, and the enum implements `Serializable` implicitly.

## How to test?

Verified end-to-end on a release (R8) build of a Flutter app consuming this core:

1. **Scoping** — a dead, unreferenced `Serializable` class in the host app is now stripped by R8 (previously kept), while the 12 config classes above remain intact and un-obfuscated.
2. **Upgrade compatibility** — a config file serialized by the currently published core (wildcard rule) is still read back without `InvalidClassException` after an in-place upgrade to this build (offline, forcing a read from the persisted file). Confirmed against a deliberately under-scoped rule set as a negative control, which fails as expected.

## Breaking Changes

None. The persisted object graphs remain fully kept, so existing serialized configs continue to deserialize across upgrades.

## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc) — N/A, handled at release
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code — N/A, proguard consumer rules are not unit-testable; validated via release-build + upgrade test (see How to test)
- [ ] I have made corresponding changes to the documentation — N/A
