### PR TITLE
chore: sdk-5196 remove stale github token usage

### DIFF
--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -13,19 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-mpx'
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Set env BRANCH_NAME
-        env:
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-              BRANCH="$PR_HEAD_REF"
-              if [[ BRANCH == 'master-mpx' || $BRANCH == 'develop-mpx' ]]; then
-                  echo "BRANCH_NAME=hotfix-mpx" >> "$GITHUB_ENV"
-              else
-                  echo "BRANCH_NAME=hotfix" >> "$GITHUB_ENV"
-              fi
+          if [[ "$GITHUB_REF_NAME" == 'master-mpx' ]]; then
+            echo "BRANCH_NAME=hotfix-mpx" >> "$GITHUB_ENV"
+          else
+            echo "BRANCH_NAME=hotfix" >> "$GITHUB_ENV"
+          fi
+
       - name: Create branch
         uses: peterjgrainger/action-create-branch@v3.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTH_GITHUB_TOKEN }}
-          with:
-            branch: '${{ BRANCH_NAME }}/${{ github.event.inputs.hotfix_name }}'
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch: '${{ env.BRANCH_NAME }}/${{ github.event.inputs.hotfix_name }}'

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -17,7 +17,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
           permission-contents: write


### PR DESCRIPTION
## Summary

- replace the stale `AUTH_GITHUB_TOKEN` PAT with the release GitHub App token
- fix the hotfix branch workflow input structure
- use the selected dispatch branch to choose the correct hotfix prefix

## Why

PR #559 removed the four stale cleanup steps described in SDK-5196. The hotfix branch workflow still referenced the expired PAT and prevented removal of the repository secret.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/create_hotfix_branch.yml`
- `git diff --check`
- repository-wide search confirms no remaining `AUTH_GITHUB_TOKEN` references

Linear: https://linear.app/rudderstack/issue/SDK-5196/android-remove-stale-auth-github-token-usage-from-release-workflows