### PR TITLE
ci: sdk-5300 fix codeql autobuild toolchain

### DIFF
--- a/android-tv/build.gradle
+++ b/android-tv/build.gradle
@@ -14,7 +14,8 @@ plugins {
     id 'kotlin-android'
 }
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
         applicationId "com.rudderstack.android_tv"

--- a/android-tv/build.gradle
+++ b/android-tv/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'kotlin-android'
 }
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
     buildToolsVersion "34.0.0"
 
     defaultConfig {

--- a/android-tv/build.gradle
+++ b/android-tv/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'kotlin-android'
 }
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
 
     defaultConfig {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
     buildToolsVersion "34.0.0"
     defaultConfig {
         minSdkVersion 19

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 34
+    compileSdk 33
     buildToolsVersion "34.0.0"
     defaultConfig {
         minSdkVersion 19

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
+    buildToolsVersion "34.0.0"
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 33

--- a/dummy-impl/build.gradle
+++ b/dummy-impl/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
     buildToolsVersion "34.0.0"
 
     defaultConfig {

--- a/dummy-impl/build.gradle
+++ b/dummy-impl/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
 
     defaultConfig {

--- a/dummy-impl/build.gradle
+++ b/dummy-impl/build.gradle
@@ -7,7 +7,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
         minSdkVersion 19

--- a/sample-cdn/build.gradle
+++ b/sample-cdn/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
 
     defaultConfig {

--- a/sample-cdn/build.gradle
+++ b/sample-cdn/build.gradle
@@ -14,7 +14,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
         applicationId "com.example.testapp1mg"

--- a/sample-cdn/build.gradle
+++ b/sample-cdn/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
     buildToolsVersion "34.0.0"
 
     defaultConfig {

--- a/sample-kotlin-integration/build.gradle
+++ b/sample-kotlin-integration/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.rudderstack.integration.test.firebase"

--- a/sample-kotlin-integration/build.gradle
+++ b/sample-kotlin-integration/build.gradle
@@ -13,7 +13,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.rudderstack.integration.test.firebase"
         minSdkVersion 21

--- a/sample-kotlin-integration/build.gradle
+++ b/sample-kotlin-integration/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
     buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.rudderstack.integration.test.firebase"

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -19,7 +19,7 @@ if (project.rootProject.file('sample-kotlin/local.properties').canRead()) {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.example.testapp1mg"

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -19,7 +19,8 @@ if (project.rootProject.file('sample-kotlin/local.properties').canRead()) {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.example.testapp1mg"
         minSdkVersion 21
@@ -79,6 +80,12 @@ dependencies {
 
     // Amplitude Device Mode
     implementation 'com.rudderstack.android.integration:amplitude:1.+'
+    implementation('org.apache.commons:commons-lang3') {
+        version {
+            strictly '3.17.0'
+        }
+        because 'AGP 7.4.2 R8 cannot process commons-lang3 3.18.0'
+    }
     implementation 'com.amplitude:android-sdk:2.25.2'
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
     implementation 'com.google.android.gms:play-services-ads:22.1.0'

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -19,7 +19,7 @@ if (project.rootProject.file('sample-kotlin/local.properties').canRead()) {
 }
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
     buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.example.testapp1mg"

--- a/sample-segment-java/build.gradle
+++ b/sample-segment-java/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
     buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.rudderstack.android.sample.java"

--- a/sample-segment-java/build.gradle
+++ b/sample-segment-java/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.rudderstack.android.sample.java"

--- a/sample-segment-java/build.gradle
+++ b/sample-segment-java/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
     defaultConfig {
         applicationId "com.rudderstack.android.sample.java"
         minSdkVersion 24


### PR DESCRIPTION
## Goal

Fix the Java/Kotlin CodeQL Default Setup job. CodeQL runs `./gradlew assemble`, so every root Android module and sample must build on the GitHub-hosted runner.

## CI failure sequence

1. AGP 7.4.2 selected Android Build Tools 30.0.3 by default. The hosted runner no longer includes that version.
2. The runner also does not include Android platform 33. CodeQL's build proxy prevents AGP from downloading missing Android SDK packages during autobuild.
3. After the Android toolchain issue was fixed, R8 failed while processing `commons-lang3:3.18.0`, which entered the sample through the dynamic Amplitude integration dependency.

## Why each change is required

### Use compile SDK 34 in all root Android modules

Android platform 34 is installed on the current GitHub-hosted runner. Platform 33 is not installed and cannot be downloaded during CodeQL autobuild. All root modules must use the available platform because CodeQL runs the root `assemble` task.

This does not change any `minSdk` or `targetSdk` value. The published `core` AAR from the PR is identical to the AAR built from the base commit, including its class files, manifest, and metadata.

AGP 7.4.2 warns that it was tested only through compile SDK 33. The complete build passes with compile SDK 34. A coordinated AGP, Gradle, and JDK upgrade is intentionally outside this CI repair.

### Pin Build Tools 34.0.0 in all root Android modules

Without an explicit version, AGP 7.4.2 selects Build Tools 30.0.3. That version is not installed on the hosted runner. Build Tools 34.0.0 is installed, so the explicit property prevents AGP from trying to download a missing version through the CodeQL proxy.

This property affects repository and CI builds only. It is not added to the published SDK metadata and does not create a build requirement for SDK consumers.

### Constrain `commons-lang3` to 3.17.0 in `sample-kotlin`

`com.rudderstack.android.integration:amplitude:1.1.1` requests `commons-lang3:3.18.0`. AGP 7.4.2's bundled R8 crashes while processing that version. Version 3.17.0 avoids the R8 crash.

The constraint is limited to the sample application. It does not enter the published `core` dependency graph. The current Amplitude integration uses only `ArrayUtils.toPrimitive` methods that are available in 3.17.0.

The Amplitude declaration still uses `1.+`. If a future Amplitude release requires a newer Commons Lang API, the sample constraint must be reviewed.

## Compatibility

The PR changes build-time tooling and one sample-only dependency. It does not change SDK runtime code, public APIs, `minSdk`, or `targetSdk`.

## Validation

- `./gradlew --no-daemon assemble` passes with Java 11: 446 tasks completed
- CodeQL Java/Kotlin analysis passes on the hosted runner
- `sample-kotlin:dependencyInsight` resolves `commons-lang3:3.17.0`
- extracted `core-release.aar` contents match the base build, including all class files and metadata
- 132 core unit tests pass with zero failures or errors
- `git diff --check` passes

Linear: https://linear.app/rudderstack/issue/SDK-5300/fix-android-sdk-codeql-autobuild-toolchain
