### PR TITLE
chore: update readme with new branding images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://rudderstack.com/">
-    <img src="https://user-images.githubusercontent.com/59817155/121357083-1c571300-c94f-11eb-8cc7-ce6df13855c9.png">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
+      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+    </picture>
   </a>
 </p>
 


### PR DESCRIPTION
## Description

Replaces the old RudderStack logo in the README with the new branding wordmark, served theme-aware via a `<picture>` element (dark variant for dark mode, light as default/fallback).

The assets are the canonical ones hosted in the rudder-sdk-js repo, so future rebrands need no change here.

Merge note: depends on rudderlabs/rudder-sdk-js#3159 — the dark asset URL 404s until that PR merges, so this should merge after it.

Docs-only change.

## Linear task

https://linear.app/rudderstack/issue/SDK-5116/update-sdk-repositories-and-packaged-assets-with-new-branding-images